### PR TITLE
Problem: user may try to add existing currency

### DIFF
--- a/client/users/addCoin.js
+++ b/client/users/addCoin.js
@@ -45,7 +45,13 @@ Template.addCoin.onRendered(function() {
 Template.addCoin.events({
   //Show and hide form help
   'focus #currencyName': function(){Session.set('currencyName', true)},
-  'blur #currencyName': function(){Session.set('currencyName', false)},
+  'blur #currencyName': function(e){
+    Session.set('currencyName', false);
+    Meteor.call('isCurrencyNameUnique', e.currentTarget.value);
+    Meteor.call('isCurrencyNameUnique', e.currentTarget.value, function(error, result){
+      if(error) {Session.set('currencyNameMessage', error.error)} else {Session.set('currencyNameMessage', null)};
+    });
+    },
   'focus #currencySymbol': function(){Session.set('currencySymbol', true)},
   'blur #currencySymbol': function(){Session.set('currencySymbol', false)},
   'focus #ICOfundsRaised': function(){Session.set('ICOfundsRaised', true)},

--- a/server/serverdb/addCoin.js
+++ b/server/serverdb/addCoin.js
@@ -1,8 +1,15 @@
 
 import { PendingCurrencies } from '../../lib/database/Currencies.js';
+import { Currencies } from '../../lib/database/Currencies.js';
 
 if (Meteor.isServer) {
 Meteor.methods({
+  isCurrencyNameUnique(name) {
+    console.log(name);
+    if (PendingCurrencies.findOne({currencyName: name}) || Currencies.findOne({currencyName: name})) {
+      throw new Meteor.Error("Looks like " + name + " is already listed or pending approval on Blockrazor!");
+    } else {return "OK"};
+  },
   addCoin(data) {
   //Check that user is logged in
   if (!Meteor.userId()) {throw new Meteor.Error("Please log in first")};

--- a/views/templates/users/addCoin.html
+++ b/views/templates/users/addCoin.html
@@ -24,6 +24,7 @@
       <li class="list-group-item bg-info">
         <b>Coin Basics</b><br />
         <input type="text" id="currencyName" name="currencyName" placeholder="Currency Name" style="width: 100%">
+        {{$.Session.get 'currencyNameMessage'}}
          {{ #if $.Session.equals 'currencyName' true }}{{> currencyName}}{{/if}}
         <input type="text" id="currencySymbol" name="currencySymbol" placeholder="SYMBOL" style="width: 100%">
         {{ #if $.Session.equals 'currencySymbol' true }}{{> currencSymbol}}{{/if}}


### PR DESCRIPTION
Solution: check both the approved and pending databases to see if the currency name the user is typing in is already in the database and tell them immediatly before filling in the rest of the form and getting irritated later

Fixes #7