### PR TITLE
problem: wallet upload error messages are not return to user and uploaded file extension is ignored

### DIFF
--- a/client/users/ratings/ratings.js
+++ b/client/users/ratings/ratings.js
@@ -143,9 +143,14 @@ if(!uploadError){
      console.log(md5);
      Meteor.call('uploadWalletImage', file.name, event.target.id, instance._id, reader.result, md5, function(error, result){
        if(error){
-         //salert
+        console.log(error)
+    sAlert.error(error.message);
+       }else{
+
+    sAlert.success('Upload Success');
+
        }
-       //console.log(result);
+
      });
    }
    reader.readAsBinaryString(file);

--- a/server/methods/imageUpload.js
+++ b/server/methods/imageUpload.js
@@ -130,13 +130,15 @@ Meteor.methods({
           return false;
         }
         var fs = Npm.require('fs');
-        var mime = Npm.require('mime-types');
-        var filename = (_walletUpoadDirectory + md5 + '.' + 'jpg'); //FIXME
-        var insert = false;
 
         //get mimetpe of uploaded file
+        var mime = Npm.require('mime-types');
         var mimetype = mime.lookup(fileName);
         var validFile = _supportedFileTypes.includes(mimetype);
+        var fileExtension = mime.extension(mimetype);
+        var filename = (_walletUpoadDirectory + md5 + '.' + fileExtension); 
+
+        var insert = false;
 
         if (!validFile) {
             throw new Meteor.Error('Error', 'File type not supported, png, gif and jpeg supported');
@@ -157,6 +159,7 @@ Meteor.methods({
             'createdBy': Meteor.user()._id,
             'flags': 0,
             'likes': 0,
+            'extension': fileExtension,
             'flaglikers': [],
             'approved': false
           });

--- a/views/templates/moderators/approveWalletImage.html
+++ b/views/templates/moderators/approveWalletImage.html
@@ -1,7 +1,7 @@
 <template name="approveWalletImage">
   <div class="row" style="display:{{display}};border:solid;">
   <div class="col-6 pull-left" style="display:block;margin-top:5px;margin-bottom:10px;float:left;min-width:400px;">
-    <img src="/static/images/wallets/{{_id}}.jpg" width="400px" height="auto"><br />
+    <img src="/static/images/wallets/{{_id}}.{{extension}}" width="400px" height="auto"><br />
   </div>
   <div class="col-6 pull-right" style="display:block;">
     This should be an image of a <b>{{currencyName}}</b> wallet. It should show the <b>{{imageOf}}</b> page/screen.<br />


### PR DESCRIPTION
solution: return success and error messages to user using sAlert #82. File type extensions are now detected via the mime-type and not hardcoded to jpg. Extension is also stored in the database as the extension was not previously. 