### PR TITLE
problem: wallet images are not displayed on the currency details page #36

### DIFF
--- a/client/normal/currencyDetail/fundamentalMetrics.js
+++ b/client/normal/currencyDetail/fundamentalMetrics.js
@@ -1,5 +1,6 @@
 import { Template } from 'meteor/templating';
 import { Features } from '../../../lib/database/Features.js';
+import { WalletImages } from '../../../lib/database/Images.js';
 
 Template.fundamentalMetrics.onRendered(function (){
   var radar = document.getElementById("radar").getContext('2d');
@@ -382,6 +383,21 @@ Template.comment.events({
     });
   }
 
+});
+
+Template.walletimages.onCreated(function(){
+  this.autorun(() => {
+    this.subscribe('walletimages', FlowRouter.getParam("_id"));
+  });
+});
+
+Template.walletimages.helpers({
+  walletimages: function () {
+    return WalletImages.find({currencyId: FlowRouter.getParam("_id")});
+  },
+  walletimagesdir(){
+    return _walletUpoadDirectoryPublic;
+  }
 });
 
 //

--- a/lib/database/Images.js
+++ b/lib/database/Images.js
@@ -2,7 +2,14 @@ import { Mongo } from 'meteor/mongo';
 export var WalletImages = new Mongo.Collection('walletimages');
 
 if(Meteor.isServer){
-  Meteor.publish('walletimages', function walletimagesPublication() {
-  return WalletImages.find();
+  Meteor.publish('walletimages', function walletimagesPublication(id) {
+
+  	if(id){
+  		return WalletImages.find({currencyId:id});
+  	}else{
+  		return WalletImages.find();
+  	}
+  
   });
+
 }

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -1,3 +1,4 @@
-_walletUpoadDirectory = '/Users/hellofriend/Dropbox/upwork/testuploads/'; //wallet upload directory ///var/www/static/images/wallets/
+_walletUpoadDirectory = '/Users/hellofriend/Documents/blockrazor/public/images/walletimages/'; //wallet upload directory ///var/www/static/images/wallets/
+_walletUpoadDirectoryPublic = '/images/walletimages/'; //The public facing image directory. Can't use above for now unless a standard is in place.
 _walletFileSizeLimit = 2097152; //max wallet filesize in bytes
 _supportedFileTypes = ['image/png', 'image/gif', 'image/jpeg']; 

--- a/views/templates/normal/currencyDetail/currencyDetail.html
+++ b/views/templates/normal/currencyDetail/currencyDetail.html
@@ -6,9 +6,21 @@
     <div class="card-body" style="display:{{bodydisplay}};">
       {{#with thiscurrency}}{{> fundamentalMetrics}}{{/with}}
       {{#with thiscurrency}}{{> features}}{{/with}}
+      {{#with thiscurrency}}{{> walletimages}}{{/with}}
     </div></div>
 
 
+</template>
+
+<template name="walletimages">
+    <div class="card border-secondary mb-3 mb-3" style="min-width:300px;overflow:hidden;margin-top:10px;">
+    <div class="card-header" style="height:50px"><h4 class="pull-left">Wallet Images
+  </h4></div>
+    <div class="card-body">
+{{#each walletimages}}
+<img src="{{walletimagesdir}}{{_id}}.{{extension}}" style="width:100px;height:100px">
+{{/each}}
+    </div></div>
 </template>
 
 <template name="fundamentalMetrics">


### PR DESCRIPTION
solution: Create a helper to the walletimages collection and display on the currency details page. Currently not styled. I had to create a new global var to assist in displaying the correct image location on the server which is public. Please advise is this approach is not suitable.