### PR TITLE
problem: users can pull wallet images from site and re-upload #32

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -44,3 +44,4 @@ service-configuration
 ostrio:logger
 ostrio:loggermongo
 todda00:friendly-slugs
+cfs:graphicsmagick

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -19,6 +19,7 @@ boilerplate-generator@1.3.1
 caching-compiler@1.1.9
 caching-html-compiler@1.1.2
 callback-hook@1.0.10
+cfs:graphicsmagick@0.0.18
 check@1.2.5
 chuangbo:cookie@1.1.0
 cleandersonlobo:sweetalert2@1.4.0

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -1,8 +1,10 @@
 _walletUpoadDirectory = '/var/www/static/images/wallets/'; //wallet upload directory ///var/www/static/images/wallets/
 _walletUpoadDirectoryPublic = '/static/images/wallets/'; //The public facing image directory. Can't use above for now unless a standard is in place.
-_walletFileSizeLimit = 2097152; //max wallet filesize in bytes
+_walletFileSizeLimit = 9999999999; //max wallet filesize in bytes
 _supportedFileTypes = ['image/png', 'image/gif', 'image/jpeg'];
 
-_coinUpoadDirectory = '/Users/hellofriend/Documents/blockrazor/public/images/coin/';
+_coinUpoadDirectory = '/var/www/static/images/coin/';
 _coinUpoadDirectoryPublic = '/images/coin/';
 _coinFileSizeLimit = 2097152; //max wallet filesize in bytes
+
+_watermarkLocation = '/var/www/static/images/watermark.png' //watermark image used in wallet watermarking.

--- a/server/methods/imageUpload.js
+++ b/server/methods/imageUpload.js
@@ -137,6 +137,8 @@ Meteor.methods({
         var validFile = _supportedFileTypes.includes(mimetype);
         var fileExtension = mime.extension(mimetype);
         var filename = (_walletUpoadDirectory + md5 + '.' + fileExtension); 
+        var filenameWatermark = (_walletUpoadDirectory + md5 + '_watermark.' + fileExtension); 
+
 
         var insert = false;
 
@@ -168,8 +170,27 @@ Meteor.methods({
         }
         if(insert != md5) {throw new Meteor.Error('Error', 'Something is wrong, please contact help.');}
 
-        fs.writeFile(filename, binaryData, {encoding: 'binary'}, function(error){
+        fs.writeFileSync(filename, binaryData, {encoding: 'binary'}, function(error){
             if(error){console.log(error)};
         });
-      }
+
+//Add watermark to image
+if(gm.isAvailable){
+    gm(filename)
+        .resize(2048, null)
+        .command('composite')
+        .gravity('SouthEast')
+        .out('-geometry', '+1+1')
+        .in(_watermarkLocation)
+        .write(filenameWatermark, function(err, stdout, stderr, command){
+            if (err){
+                console.log("Error applying watermark");
+                console.log(err);
+            }
+        });
+
+    }else{
+      console.log('required gm dependicies are not available')
+    }
+  }
 });


### PR DESCRIPTION
solution: watermark uploaded images to enable easy detection of re-used images. GM library used and can be used on other tickets. Sample watermark provided here: https://i.imgur.com/sN6PcN1.png