### PR TITLE
Problem: modals broken, help link broken, full width layout for comments

### DIFF
--- a/client/normal/currency.css
+++ b/client/normal/currency.css
@@ -211,9 +211,8 @@ body{font-family: 'Open Sans', sans-serif; font-size: 14px; font-weight: 400;}
   color: #fff;
   background-color: #02b3e4;
 }
-
-
 .p15{ padding: 15px;} 
+
 .currencyDetailBox.card h5 { margin: 0 -20px 10px;  border-bottom: solid 1px #ddd; color:#fff;   padding: 10px 15px;  background: #868e96;}
 .currencyDetailBox.card h3 { margin: 15 0 0;}
 .commentThread .commentText .text-muted{ float: right;}

--- a/client/normal/currency.css
+++ b/client/normal/currency.css
@@ -1,11 +1,3 @@
-body{font-family: 'Open Sans', sans-serif; font-size: 14px; font-weight: 400;}
-
-* {
-  border-radius: 0 !important;
-}
-
-
-
 .bg-good {
   background-color: #91C499;
 }
@@ -23,7 +15,7 @@ body{font-family: 'Open Sans', sans-serif; font-size: 14px; font-weight: 400;}
 }
 
 .currencyDetailBox {
-
+  border-bottom: solid 1px;
   padding-bottom: 5px;
   padding-left: 5px;
   padding-right: 5px;
@@ -35,7 +27,6 @@ body{font-family: 'Open Sans', sans-serif; font-size: 14px; font-weight: 400;}
 .bigCommentBox {
   display:block;
   width:100%;
-  border: solid 1px #ddd;
   height:auto;
   float:right;
   clear: both;
@@ -53,15 +44,19 @@ body{font-family: 'Open Sans', sans-serif; font-size: 14px; font-weight: 400;}
 .commentBody {
   height:auto;
   width:100%;
+  border-style: solid;
+  border-width: 1px;
+  border-bottom: none;
   text-align: justify;
-  padding:10px;
-  background: #f5f5f5;
+  padding: 3px;
 
 }
 
 .commentAnalysis {
   width:30px;
   height:100px;
+  border-style: solid;
+  border-width: 1px;
 }
 
 .commentResponse {
@@ -81,9 +76,12 @@ body{font-family: 'Open Sans', sans-serif; font-size: 14px; font-weight: 400;}
   display: block;
   padding-right: 5px;
   padding-left: 5px;
+
   height:24px;
   width: 100%;
-
+  border-bottom: solid 1px;
+  border-left: solid 1px;
+  border-right: solid 1px;
 }
 
 .heading-wrapper i {
@@ -211,18 +209,3 @@ body{font-family: 'Open Sans', sans-serif; font-size: 14px; font-weight: 400;}
   color: #fff;
   background-color: #02b3e4;
 }
-.p15{ padding: 15px;} 
-
-.currencyDetailBox.card h5 { margin: 0 -20px 10px;  border-bottom: solid 1px #ddd; color:#fff;   padding: 10px 15px;  background: #868e96;}
-.currencyDetailBox.card h3 { margin: 15 0 0;}
-.commentThread .commentText .text-muted{ float: right;}
-.newcomment-Yk3JP2qao5KdCHjHQ textarea .replyText{border: solid 1px #ddd;  margin-top: 10px; min-height: 50px;}
-.replyFooter-Yk3JP2qao5KdCHjHQ, .replyFooter-LhSrXZoNqWB4xWtdP {text-align: right; margin: 15px 0px; }
-.showAddNewRedflag, #addNewFeature{ margin:0 0 0;}
-.commentFooter{ margin:5px 0 10px}
-.commentBody { float: left;}
-.commentFooter .fa-thumbs-up{color:#f6c163}
-.commentFooter .fa-thumbs-down {color:#eb6357}
-.commentFooter .fa-comments-o {color:#37b358;}
-.commentFooter .fa-flag{color:#5f99f5;}
-.replyFooter-5CSu6iPkNavLe8bNT{ float:right;}

--- a/views/templates/normal/currencyDetail/features.html
+++ b/views/templates/normal/currencyDetail/features.html
@@ -1,80 +1,24 @@
 <template name="features">
-  
-  
-  
-    <div class="modal fade" id="addFeatureModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title" id="exampleModalLabel">Adding a new feature</h5>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </div>
-          <div class="modal-body">
-            You're adding a {{currencyName}} feature. You will be credited with a bounty of {{bountyamount}} ZZR in 7 days as long as it:
-            <ul>
-              <li>Maintains 3 or more stars</li>
-              <li>Is not sent to the Sin Bin by a moderator</li>
-            </ul>
-            Here's an example feature from Monero:<br />
-            <i>Privacy - all transactions made with Monero are private and untraceable.</i>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-primary" data-dismiss="modal" aria-label="Close">Thanks, don't show this again</button>
-          </div>
-        </div>
-      </div>
-    </div>
-  
-    <div class="modal fade" id="wymiModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title" id="exampleModalLabel">Commenting</h5>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </div>
-          <div class="modal-body">
-            <p>You'll be asked how much <i>wymi</i> you want to give your comment. </p>
-            <p>You must have enough avalable balance in your wallet to fund the amount you choose.</p>
-            <p>If your comment becomes the <i>top comment</i> in the thread, you get <i>triple</i> your wymi back!
-            If not, your wymi is <i>returned to you in full</i>. Comments sent to the Sin Bin for violating
-            the rules shall forfeit their wymi.</p>
-            <p>The wymi is currently optional but a minimum amount may be implimented in future depending on how much spam etc there is.</p>
-            <h5>Rules</h5>
-            If you think you're doing the right thing, you probably are.
-            <ul>
-              <li>No spamming</li>
-              <li>No personal attacks or abuse</li>
-              <li>Warning people about scams etc is perfectly fine, but <i>malicious</i> FUD is not.</li>
-            </ul>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-primary" data-dismiss="modal" aria-label="Close">Close</button>
-          </div>
-        </div>
-      </div>
-    </div>
-  
-  
-  
-  
-  
-  <div class="modal fade" id="featureModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+
+
+
+  <div class="modal fade" id="addFeatureModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title" id="exampleModalLabel">Add a new feature</h5>
+          <h5 class="modal-title" id="exampleModalLabel">Adding a new feature</h5>
           <button type="button" class="close" data-dismiss="modal" aria-label="Close">
             <span aria-hidden="true">&times;</span>
           </button>
         </div>
         <div class="modal-body">
-          It looks like {{currencyName}} has only recently been added to Blockrazor and
-          its features have not yet been added. This is a great opportunity for you to
-          add one of {{currencyName}}'s features and earn some Krazor!
+          You're adding a {{currencyName}} feature. You will be credited with a bounty of {{bountyamount}} ZZR in 7 days as long as it:
+          <ul>
+            <li>Maintains 3 or more stars</li>
+            <li>Is not sent to the Sin Bin by a moderator</li>
+          </ul>
+          Here's an example feature from Monero:<br />
+          <i>Privacy - all transactions made with Monero are private and untraceable.</i>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-primary" data-dismiss="modal" aria-label="Close">Thanks, don't show this again</button>
@@ -82,80 +26,155 @@
       </div>
     </div>
   </div>
-  {{featureModal}}
-  
-  <div class="currencyDetailBox card">
-   <div class="container">
-     <h5 class="text-left p15 currencyDetailHeading featuresheading">Features</h5>
-        <div class="row">
-       <div style="padding:0;" class="hide-btn col-12">
-          <button class="btn btn-primary pull-left showFlagged" style="margin-top:6px;">
-            <i class="fa fa-flag" aria-hidden="true"></i> Show flagged  </button>
-            <button class="btn btn-primary pull-right showAddNewFeature" style="margin-top:6px;">
-          <i class="fa fa-plus" aria-hidden="true"></i> Add a feature
-        </button>
-  </div> 
-     
-      
-      
-      <div class="col-12">
-           <div id="addNewFeature" style="display:none;margin-bottom:10px;">
-          <h3>Rules:</h3>
-          <ul class="list-unstyled">
-            <li>Use clear language, keep it as short as possible</li>
-            <li>No jokes (people new to crypto will just be confused)</li>
-            <li>Any claims must be factually correct</li>
+
+  <div class="modal fade" id="wymiModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="exampleModalLabel">Commenting</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <p>You'll be asked how much <i>wymi</i> you want to give your comment. </p>
+          <p>You must have enough avalable balance in your wallet to fund the amount you choose.</p>
+          <p>If your comment becomes the <i>top comment</i> in the thread, you get <i>triple</i> your wymi back!
+          If not, your wymi is <i>returned to you in full</i>. Comments sent to the Sin Bin for violating
+          the rules shall forfeit their wymi.</p>
+          <p>The wymi is currently optional but a minimum amount may be implimented in future depending on how much spam etc there is.</p>
+          <h5>Rules</h5>
+          If you think you're doing the right thing, you probably are.
+          <ul>
+            <li>No spamming</li>
+            <li>No personal attacks or abuse</li>
+            <li>Warning people about scams etc is perfectly fine, but <i>malicious</i> FUD is not.</li>
           </ul>
-          <div class="message">
-            <textarea class="" id="featureName" style="width:100%; min-height: 120px;" maxlength="140" minlength="6"></textarea>
-            </div>
-          <div class="text-right">
-            <button class="btn btn-primary float-left submitNewFeature">Submit 
-            <i class="fa fa-question-circle help" aria-hidden="true"></i>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" data-dismiss="modal" aria-label="Close">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+<div class="modal fade" id="featureModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exampleModalLabel">Add a new feature</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        It looks like {{currencyName}} has only recently been added to Blockrazor and
+        its features have not yet been added. This is a great opportunity for you to
+        add one of {{currencyName}}'s features and earn some Krazor!
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-dismiss="modal" aria-label="Close">Thanks, don't show this again</button>
+      </div>
+    </div>
+  </div>
+</div>
+{{featureModal}}
+
+<div class="currencyDetailBox" >
+  <div style="display:flex;width:100%;">
+    <div style="width:20%; float:left;">
+      <button class="btn btn-primary pull-left showFlagged" style="margin-top:6px;">
+        <i class="fa fa-flag" aria-hidden="true"></i> Show flagged
       </button>
-                       </div>
+    </div>
+    <div style="width:60%">
+      <h5 class="text-center currencyDetailHeading featuresheading">Features</h5>
+      <div id="addNewFeature" style="display:none;margin-bottom:10px;">
+        <b>Rules:</b><br />
+        <ul>
+          <li>Use clear language, keep it as short as possible</li>
+          <li>No jokes (people new to crypto will just be confused)</li>
+          <li>Any claims must be factually correct</li>
+        </ul>
+        <textarea class="" id="featureName" style="width:100%" maxlength="140" minlength="6"></textarea><br />
+        <div style="display:flex;"><button class="btn btn-primary float-left submitNewFeature">Submit</button>
+          <h4>&nbsp;&nbsp;<i class="fa fa-question-circle help" aria-hidden="true"></i></h4>
           <div class="float-right" id="charNum" style="margin-left:50px;"></div>
         </div>
-      
       </div>
-      </div>
-      </div>
-     
-     
-    
-  
-      <div class="row commentThread">
-      {{#unless reactiveVar 'showflagged'}}
-        {{#each features}}<div class="col-12">{{> feature}}</div>{{/each}}
-      {{/unless}}
-  
-      {{#if reactiveVar 'showflagged'}}
-        {{#each flaggedfeatures}}<div class="col-12">{{> feature}}</div>{{/each}}
-      {{/if}}
     </div>
-  
-  
-  
-  
+    <div style="width:20%;float:right;">
+      <button class="btn btn-primary pull-right showAddNewFeature" style="margin-top:6px;">
+        <i class="fa fa-plus" aria-hidden="true"></i> Add a feature
+      </button>
+    </div>
   </div>
-  </template>
-  
-  <template name="feature">
-      <div class="bigCommentBox">
-        <div class="commentBody">
-          <div class="commentText">{{featureName}}<small class="text-muted" style="white-space:nowrap;">  &#x2015;added by {{author}}</small></div>
-        </div>
-        <div class="commentFooter"><div class="pull-left"><i class="fa fa-thumbs-down" aria-hidden="true"></i>  <i class="fa fa-thumbs-up fa-flip-horizontal" aria-hidden="true"></i></div><div class="pull-right"><i class="fa fa-flag flag" aria-hidden="true"></i><i class="fa fa-comments-o comments" aria-hidden="true" style="margin-left:10px;"><small>{{numComments}}</small></i></div></div>
+
+    <div class="row commentThread">
+    {{#unless reactiveVar 'showflagged'}}
+      {{#each features}}<div class="col-lg-6">{{> feature}}</div>{{/each}}
+    {{/unless}}
+
+    {{#if reactiveVar 'showflagged'}}
+      {{#each flaggedfeatures}}<div class="col-lg-6">{{> feature}}</div>{{/each}}
+    {{/if}}
+  </div>
+
+
+
+
+</div>
+</template>
+
+<template name="feature">
+    <div class="bigCommentBox">
+      <div class="commentBody">
+        <div class="commentText">{{featureName}}<small class="text-muted" style="white-space:nowrap;">  &#x2015;added by {{author}}</small></div>
       </div>
-      <div class="newcomment-{{_id}}" style="display:none;">
-      <textarea id="replyText-{{_id}}" class="replyText" style="width:100%;height:30px;" maxlength="140" minlength="6" placeholder="reply"></textarea>
-      <div class="replyFooter-{{_id}}" style="display:none;">Wymi amount<i class="fa fa-question-circle wymihelp" aria-hidden="true">
-        </i>:<input 
-      class="mwymi" style="width:40px; margin-right: 4px;"><button class="btn btn-primary submitNewComment">Submit</button>
-      <div class="float-right" id="replyCharNum{{_id}}" style="position:absolute;right:0; bottom:0px;margin-right:20px;"></div>
+      <div class="commentFooter"><div class="pull-left"><i class="fa fa-thumbs-down" aria-hidden="true"></i>  <i class="fa fa-thumbs-up fa-flip-horizontal" aria-hidden="true"></i></div><div class="pull-right"><i class="fa fa-flag flag" aria-hidden="true"></i><i class="fa fa-comments-o comments" aria-hidden="true" style="margin-left:10px;"><small>{{numComments}}</small></i></div></div>
+    </div>
+    <div class="newcomment-{{_id}}" style="display:none;">
+    <textarea id="replyText-{{_id}}" class="replyText" style="width:100%;height:30px;" maxlength="140" minlength="6" placeholder="reply"></textarea><br />
+    <div class="replyFooter-{{_id}}" style="display:none;">Wymi amount<i class="fa fa-question-circle wymihelp" aria-hidden="true"></i>:<input class="mwymi" style="width:40px; margin-right: 4px;"><button class="btn btn-primary submitNewComment">Submit</button><div class="float-right" id="replyCharNum{{_id}}" style="position:absolute;right:0; bottom:0px;margin-right:20px;"></div></div>
+  </div>
+
+  <div class="modal fade" id="flagModal-{{_id}}" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">You are flagging:</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <p><b><i>"{{featureName}}"</i></b></p>
+          Written by: {{author}}
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-danger flagButton">Report</button>
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        </div>
       </div>
     </div>
-  
+  </div>
+
+{{#each comments}}{{> comment}}{{/each}}
+</template>
+
+
+
+
+<template name="comment">
+    <div class="bigCommentBox commentParent-{{parentId}}" style="width:90%;display:none;">
+      <div class="commentBody">
+        <div class="commentText">{{comment}} <small class="text-muted" style="white-space:nowrap;">&#x2015;{{author}}</small>
+      </div>
+      </div>
+<div class="commentFooter"><div class="pull-left"><i class="fa fa-thumbs-down" aria-hidden="true"></i>  <i class="fa fa-thumbs-up fa-flip-horizontal" aria-hidden="true"></i></div><div class="pull-right"><i class="fa fa-flag flag" aria-hidden="true"></i></div></div>
+    </div>
+
+
     <div class="modal fade" id="flagModal-{{_id}}" tabindex="-1" role="dialog">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
@@ -166,51 +185,14 @@
             </button>
           </div>
           <div class="modal-body">
-            <p><b><i>"{{featureName}}"</i></b></p>
+            <p><b><i>"{{comment}}"</i></b></p>
             Written by: {{author}}
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-danger flagButton">Report</button>
+            <button type="button" class="btn btn-danger commentFlag">Report</button>
             <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
           </div>
         </div>
       </div>
     </div>
-  
-  {{#each comments}}{{> comment}}{{/each}}
-  </template>
-  
-  
-  
-  
-  <template name="comment">
-      <div class="bigCommentBox commentParent-{{parentId}}" style="width:90%;display:none;">
-        <div class="commentBody">
-          <div class="commentText">{{comment}} <small class="text-muted" style="white-space:nowrap;">&#x2015;{{author}}</small>
-        </div>
-        </div>
-  <div class="commentFooter"><div class="pull-left"><i class="fa fa-thumbs-down" aria-hidden="true"></i>  <i class="fa fa-thumbs-up fa-flip-horizontal" aria-hidden="true"></i></div><div class="pull-right"><i class="fa fa-flag flag" aria-hidden="true"></i></div></div>
-      </div>
-  
-  
-      <div class="modal fade" id="flagModal-{{_id}}" tabindex="-1" role="dialog">
-        <div class="modal-dialog" role="document">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h5 class="modal-title">You are flagging:</h5>
-              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
-            <div class="modal-body">
-              <p><b><i>"{{comment}}"</i></b></p>
-              Written by: {{author}}
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-danger commentFlag">Report</button>
-              <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-            </div>
-          </div>
-        </div>
-      </div>
-  </template>
+</template>

--- a/views/templates/normal/currencyDetail/redflags.html
+++ b/views/templates/normal/currencyDetail/redflags.html
@@ -1,64 +1,8 @@
 <template name="redflags">
-  
-  
-  
-    <div class="modal fade" id="addRedFlagModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title" id="exampleModalLabel">Flag Currency</h5>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </div>
-          <div class="modal-body">
-            RED FLAFYou're red flagging {{currencyName}}. You will be credited with a bounty of {{bountyamount}} ZZR in 7 days as long as it:
-            <ul>
-              <li>Maintains 3 or more stars</li>
-              <li>Is not sent to the Sin Bin by a moderator</li>
-            </ul>
-            Here's an example red flag from Monero:<br />
-            <i>Privacy - all transactions made with Monero are private and untraceable.</i>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-primary" data-dismiss="modal" aria-label="Close">Thanks, don't show this again</button>
-          </div>
-        </div>
-      </div>
-    </div>
-  
-    <div class="modal fade" id="wymiModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title" id="exampleModalLabel">Commenting</h5>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </div>
-          <div class="modal-body">
-            <p>You'll be asked how much <i>wymi</i> you want to give your comment. </p>
-            <p>You must have enough avalable balance in your wallet to fund the amount you choose.</p>
-            <p>If your comment becomes the <i>top comment</i> in the thread, you get <i>triple</i> your wymi back!
-            If not, your wymi is <i>returned to you in full</i>. Comments sent to the Sin Bin for violating
-            the rules shall forfeit their wymi.</p>
-            <p>The wymi is currently optional but a minimum amount may be implimented in future depending on how much spam etc there is.</p>
-            <h5>Rules</h5>
-            If you think you're doing the right thing, you probably are.
-            <ul>
-              <li>No spamming</li>
-              <li>No personal attacks or abuse</li>
-              <li>Warning people about scams etc is perfectly fine, but <i>malicious</i> FUD is not.</li>
-            </ul>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-primary" data-dismiss="modal" aria-label="Close">Close</button>
-          </div>
-        </div>
-      </div>
-    </div>
-  
-  <div class="modal fade" id="featureModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+
+
+
+  <div class="modal fade" id="addRedFlagModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
@@ -68,9 +12,13 @@
           </button>
         </div>
         <div class="modal-body">
-          It looks like {{currencyName}} has only recently been added to Blockrazor and
-          its red flags have not yet been added. This is a great opportunity for you to
-          add one of {{currencyName}}'s features and earn some Krazor!
+          RED FLAFYou're red flagging {{currencyName}}. You will be credited with a bounty of {{bountyamount}} ZZR in 7 days as long as it:
+          <ul>
+            <li>Maintains 3 or more stars</li>
+            <li>Is not sent to the Sin Bin by a moderator</li>
+          </ul>
+          Here's an example red flag from Monero:<br />
+          <i>Privacy - all transactions made with Monero are private and untraceable.</i>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-primary" data-dismiss="modal" aria-label="Close">Thanks, don't show this again</button>
@@ -78,71 +26,155 @@
       </div>
     </div>
   </div>
-  {{featureModal}}
-  
-  <div class="currencyDetailBox card">
-    <div class="container">
-      <h5 class="text-left p15 currencyDetailHeading featuresheading">Red Flags</h5>
-      <div class="row">
-       <div style="padding:0;" class="hide-btn col-12">
-           
-               <button class="btn btn-primary showRedFlagged ">Hide</button>
-            <button class="btn btn-primary pull-right showAddNewRedflag"><i class="fa fa-plus" aria-hidden="true">
-              </i> Red Flag Currency</button>
-    
-      </div>
-      <div class=col>
-       
-        <div id="showAddNewRedflag" style="display:none;">
-         <h3>Rules:</h3>
-          <ul class="list-unstyled">
-            <li>Use clear language, keep it as short as possible</li>
-            <li>No jokes (people new to crypto will just be confused)</li>
-            <li>Any claims must be factually correct</li>
+
+  <div class="modal fade" id="wymiModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="exampleModalLabel">Commenting</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <p>You'll be asked how much <i>wymi</i> you want to give your comment. </p>
+          <p>You must have enough avalable balance in your wallet to fund the amount you choose.</p>
+          <p>If your comment becomes the <i>top comment</i> in the thread, you get <i>triple</i> your wymi back!
+          If not, your wymi is <i>returned to you in full</i>. Comments sent to the Sin Bin for violating
+          the rules shall forfeit their wymi.</p>
+          <p>The wymi is currently optional but a minimum amount may be implimented in future depending on how much spam etc there is.</p>
+          <h5>Rules</h5>
+          If you think you're doing the right thing, you probably are.
+          <ul>
+            <li>No spamming</li>
+            <li>No personal attacks or abuse</li>
+            <li>Warning people about scams etc is perfectly fine, but <i>malicious</i> FUD is not.</li>
           </ul>
-         <div class="message">
-            <textarea class="" id="redflagContent" style="width:100% ; min-height:120px;" maxlength="140" minlength="6"></textarea>
-            </div>
-          <div class="text-right">
-            <button class="btn btn-primary float-left submitRedFlag">Submit <i class="fa fa-question-circle help" aria-hidden="true"></i></button>
-              </div>
-          <div class="card" id="charNum" style="margin-left:50px;"></div>
-       
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" data-dismiss="modal" aria-label="Close">Close</button>
         </div>
       </div>
-      </div>
     </div>
-  
-      <div class="row commentThread">
-      {{#unless reactiveVar 'showredflagged'}}
-        {{#each redflags}}<div class="col-12">{{> redflag}}</div>{{/each}}
-      {{/unless}}
-  
-      {{#if reactiveVar 'showredflagged'}}
-        {{#each flaggedfeatures}}<div class="col-12">{{> feature}}</div>{{/each}}
-      {{/if}}
-    </div>
-  
-  
-  
-  
   </div>
-  </template>
-  
-  <template name="redflag">
-      <div class="bigCommentBox">
-        <div class="commentBody">
-          <div class="commentText">{{name}}<small class="text-muted" style="white-space:nowrap;">  &#x2015;added by {{author}}</small></div>
-        </div>
-        <div class="commentFooter"><div class="pull-left"><i class="fa fa-thumbs-down" aria-hidden="true"></i>  <i class="fa fa-thumbs-up fa-flip-horizontal" aria-hidden="true"></i></div><div class="pull-right"><i class="fa fa-flag flag" aria-hidden="true"></i><i class="fa fa-comments-o comments" aria-hidden="true" style="margin-left:10px;"><small>{{numComments}}</small></i></div></div>
+
+<div class="modal fade" id="featureModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exampleModalLabel">Flag Currency</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
       </div>
-      <div class="newcomment-{{_id}}" style="display:none;">
-      <textarea id="replyText-{{_id}}" class="replyText" style="width:100%;height:30px;" maxlength="140" minlength="6" placeholder="reply"></textarea><br />
-      <div class="replyFooter-{{_id}}" style="display:none;">Wymi amount<i class="fa fa-question-circle wymihelp" aria-hidden="true"></i>:
-      <input class="mwymi" style="width:40px; margin-right: 4px;">
-      <button class="btn btn-primary submitNewComment">Submit</button><div class="float-right" id="replyCharNum{{_id}}" style="position:absolute;right:0; bottom:0px;margin-right:20px;"></div></div>
+      <div class="modal-body">
+        It looks like {{currencyName}} has only recently been added to Blockrazor and
+        its red flags have not yet been added. This is a great opportunity for you to
+        add one of {{currencyName}}'s features and earn some Krazor!
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-dismiss="modal" aria-label="Close">Thanks, don't show this again</button>
+      </div>
     </div>
-  
+  </div>
+</div>
+{{featureModal}}
+
+<div class="currencyDetailBox" >
+  <div style="display:flex;width:100%;">
+    <div style="width:20%; float:left;">
+      <button class="btn btn-primary pull-left showRedFlagged" style="margin-top:6px;">
+        Hide
+      </button>
+    </div>
+    <div style="width:60%">
+      <h5 class="text-center currencyDetailHeading featuresheading">Red Flags</h5>
+      <div id="showAddNewRedflag" style="display:none;margin-bottom:10px;">
+        <b>Rules:</b><br />
+        <ul>
+          <li>Use clear language, keep it as short as possible</li>
+          <li>No jokes (people new to crypto will just be confused)</li>
+          <li>Any claims must be factually correct</li>
+        </ul>
+        <textarea class="" id="redflagContent" style="width:100%" maxlength="140" minlength="6"></textarea><br />
+        <div style="display:flex;"><button class="btn btn-primary float-left submitRedFlag">Submit</button>
+          <h4>&nbsp;&nbsp;<i class="fa fa-question-circle help" aria-hidden="true"></i></h4>
+          <div class="float-right" id="charNum" style="margin-left:50px;"></div>
+        </div>
+      </div>
+    </div>
+    <div style="width:20%;float:right;">
+      <button class="btn btn-primary pull-right showAddNewRedflag" style="margin-top:6px;">
+        <i class="fa fa-plus" aria-hidden="true"></i> Red Flag Currency
+      </button>
+    </div>
+  </div>
+
+    <div class="row commentThread">
+    {{#unless reactiveVar 'showredflagged'}}
+      {{#each redflags}}<div class="col-lg-6">{{> redflag}}</div>{{/each}}
+    {{/unless}}
+
+    {{#if reactiveVar 'showredflagged'}}
+      {{#each flaggedfeatures}}<div class="col-lg-6">{{> feature}}</div>{{/each}}
+    {{/if}}
+  </div>
+
+
+
+
+</div>
+</template>
+
+<template name="redflag">
+    <div class="bigCommentBox">
+      <div class="commentBody">
+        <div class="commentText">{{name}}<small class="text-muted" style="white-space:nowrap;">  &#x2015;added by {{author}}</small></div>
+      </div>
+      <div class="commentFooter"><div class="pull-left"><i class="fa fa-thumbs-down" aria-hidden="true"></i>  <i class="fa fa-thumbs-up fa-flip-horizontal" aria-hidden="true"></i></div><div class="pull-right"><i class="fa fa-flag flag" aria-hidden="true"></i><i class="fa fa-comments-o comments" aria-hidden="true" style="margin-left:10px;"><small>{{numComments}}</small></i></div></div>
+    </div>
+    <div class="newcomment-{{_id}}" style="display:none;">
+    <textarea id="replyText-{{_id}}" class="replyText" style="width:100%;height:30px;" maxlength="140" minlength="6" placeholder="reply"></textarea><br />
+    <div class="replyFooter-{{_id}}" style="display:none;">Wymi amount<i class="fa fa-question-circle wymihelp" aria-hidden="true"></i>:<input class="mwymi" style="width:40px; margin-right: 4px;"><button class="btn btn-primary submitNewComment">Submit</button><div class="float-right" id="replyCharNum{{_id}}" style="position:absolute;right:0; bottom:0px;margin-right:20px;"></div></div>
+  </div>
+
+  <div class="modal fade" id="flagModal-{{_id}}" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">You are flagging:</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <p><b><i>"{{featureName}}"</i></b></p>
+          Written by: {{author}}
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-danger flagButton">Report</button>
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+{{#each comments}}{{> comment}}{{/each}}
+</template>
+
+
+
+
+<template name="redflagComment">
+    <div class="bigCommentBox commentParent-{{parentId}}" style="width:90%;display:none;">
+      <div class="commentBody">
+        <div class="commentText">{{comment}} <small class="text-muted" style="white-space:nowrap;">&#x2015;{{author}}</small>
+      </div>
+      </div>
+<div class="commentFooter"><div class="pull-left"><i class="fa fa-thumbs-down" aria-hidden="true"></i>  <i class="fa fa-thumbs-up fa-flip-horizontal" aria-hidden="true"></i></div><div class="pull-right"><i class="fa fa-flag flag" aria-hidden="true"></i></div></div>
+    </div>
+
+
     <div class="modal fade" id="flagModal-{{_id}}" tabindex="-1" role="dialog">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
@@ -153,51 +185,14 @@
             </button>
           </div>
           <div class="modal-body">
-            <p><b><i>"{{featureName}}"</i></b></p>
+            <p><b><i>"{{comment}}"</i></b></p>
             Written by: {{author}}
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-danger flagButton">Report</button>
+            <button type="button" class="btn btn-danger commentFlag">Report</button>
             <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
           </div>
         </div>
       </div>
     </div>
-  
-  {{#each comments}}{{> comment}}{{/each}}
-  </template>
-  
-  
-  
-  
-  <template name="redflagComment">
-      <div class="bigCommentBox commentParent-{{parentId}}" style="width:90%;display:none;">
-        <div class="commentBody">
-          <div class="commentText">{{comment}} <small class="text-muted" style="white-space:nowrap;">&#x2015;{{author}}</small>
-        </div>
-        </div>
-  <div class="commentFooter"><div class="pull-left"><i class="fa fa-thumbs-down" aria-hidden="true"></i>  <i class="fa fa-thumbs-up fa-flip-horizontal" aria-hidden="true"></i></div><div class="pull-right"><i class="fa fa-flag flag" aria-hidden="true"></i></div></div>
-      </div>
-  
-  
-      <div class="modal fade" id="flagModal-{{_id}}" tabindex="-1" role="dialog">
-        <div class="modal-dialog" role="document">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h5 class="modal-title">You are flagging:</h5>
-              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
-            <div class="modal-body">
-              <p><b><i>"{{comment}}"</i></b></p>
-              Written by: {{author}}
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-danger commentFlag">Report</button>
-              <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-            </div>
-          </div>
-        </div>
-      </div>
-  </template>
+</template>


### PR DESCRIPTION
#257 removes some necessary modals and other functionality, moves the help button to *within* a submit button so there's no way to get help without also submitting the form, and it forces all comments to be full-width which is just weird and silly.

Solution: revert b5f47f1 and edf91f5