### PR TITLE
Problem: Users can take a new bounty while an existing bounty is running (#275)

### DIFF
--- a/client/normal/bounties/bounties.js
+++ b/client/normal/bounties/bounties.js
@@ -110,9 +110,18 @@ Template.bountyRender.helpers({
     return canContinue(this._id)
   },
   buttonClass: function() {
-    if(this.currentlyAvailable == true) {
-        return "btn-outline-primary takeBounty";
-    } else { return "btn-outline-secondary";}
+    let b = Bounties.findOne({
+      userId: Meteor.userId(),
+      completed: false
+    })
+
+    // grey out the button if the bounty is not currently available, or if the use is already working on another bounty
+    // of course, don't grey it out if the user can continue tha current bounty
+    if(this.currentlyAvailable === false || (Cookies.get('workingBounty') === 'true' && b && b.expiresAt > Date.now()) && !canContinue(this._id)) {
+        return "btn-outline-secondary";
+    } else { 
+      return "btn-outline-primary takeBounty"
+    }
   },
   reward: function () {
     return calculateReward.call(this, Template.instance().view.parentView.parentView.parentView.templateInstance().now.get())


### PR DESCRIPTION
Solution: Grey out the 'take bounty' buttons if the user is already working on another bounty to prevent him/her from starting multiple bounties