### PR TITLE
Problem: Users can't delete their own hash power data (#328)

### DIFF
--- a/imports/api/hashpower/methods.js
+++ b/imports/api/hashpower/methods.js
@@ -267,6 +267,29 @@ Meteor.methods({
             return 'not-ok'
         }
     },
+    deleteHashpower: id => {
+		if (Meteor.userId()) {
+			let hp = HashPower.findOne({
+				_id: id
+			})
+
+			if (hp) {
+				if (hp.createdBy === Meteor.userId()) { // you can only delete the hash power data if you've added it
+					HashPower.remove({
+						_id: id
+					})
+
+					removeUserCredit(hp.reward || 0, hp.createdBy, 'removing added hash power data.') // remove the reward
+				} else {
+					throw new Meteor.Error('Error.', 'Error ocurred while deleting.')
+				}
+			} else {
+				throw new Meteor.Error('Error.', 'Wrong id.')
+			}
+		} else {
+			throw new Meteor.Error('Error.', 'You have to log in first.')
+		}
+	},
 	updateAverages: () => {
 		HashAlgorithm.find({}).fetch().forEach(i => {
 			Meteor.call('calculateAverage', i._id, (err, data) => {})

--- a/imports/ui/pages/hashpower/allHashpower.js
+++ b/imports/ui/pages/hashpower/allHashpower.js
@@ -38,9 +38,7 @@ Template.allHashpower.helpers({
 		}) || {}).name || ''
 	},
 	canDelete: function() {
-		return this.createdBy === Meteor.userId() || (UserData.findOne({
-			_id: Meteor.userId()
-		}) || {}).moderator
+		return this.createdBy === Meteor.userId()
 	},
 	canFlag: function() {
 		return this.createdBy !== Meteor.userId() // can't flag your own submission


### PR DESCRIPTION
Solution: Add the 'deleteHashpower' method once again and review the 'canDelete' helper to only allow users to delete their own hash data