### PR TITLE
problem: prop validate test script slow

### DIFF
--- a/imports/test/server/unit/validateprop.test.js
+++ b/imports/test/server/unit/validateprop.test.js
@@ -16,42 +16,35 @@ var test_watermarkLocation = '/Users/hellofriend/Documents/upload/watermark.png'
 var fs = require('fs');
 var propertiesFile = process.env.PWD + '/lib/properties.js';
 
-describe('Test on I/O', function() {
+var d = fs.readFileSync(propertiesFile).toString();
+
+describe('Validate properties.js', function() {
 
     it('_walletUpoadDirectory valid', function() {
-        var d = fs.readFileSync(propertiesFile).toString();
         assert.ok(d.includes(test_walletUpoadDirectory))
     })
     it('_walletUpoadDirectoryPublic valid', function() {
-        var d = fs.readFileSync(propertiesFile).toString();
         assert.ok(d.includes(test_walletUpoadDirectoryPublic))
     })
     it('_coinUpoadDirectory  valid', function() {
-        var d = fs.readFileSync(propertiesFile).toString();
         assert.ok(d.includes(test_coinUpoadDirectory ))
     })
     it('_coinUpoadDirectoryPublic valid', function() {
-        var d = fs.readFileSync(propertiesFile).toString();
         assert.ok(d.includes(test_coinUpoadDirectoryPublic))
     })
     it('_hashPowerUploadDirectory valid', function() {
-        var d = fs.readFileSync(propertiesFile).toString();
         assert.ok(d.includes(test_hashPowerUploadDirectory))
     })
     it('_hashPowerUploadDirectoryPublic valid', function() {
-        var d = fs.readFileSync(propertiesFile).toString();
         assert.ok(d.includes(test_hashPowerUploadDirectoryPublic))
     })
     it('_profilePictureUploadDirectory valid', function() {
-        var d = fs.readFileSync(propertiesFile).toString();
         assert.ok(d.includes(test_profilePictureUploadDirectory))
     })
     it('_profilePictureUploadDirectoryPublic valid', function() {
-        var d = fs.readFileSync(propertiesFile).toString();
         assert.ok(d.includes(test_profilePictureUploadDirectoryPublic))
     })
     it('_watermarkLocation valid', function() {
-        var d = fs.readFileSync(propertiesFile).toString();
         assert.ok(d.includes(test_watermarkLocation))
     })
 


### PR DESCRIPTION
solution: no need to read the file each time, just once now