### PR TITLE
Problem: /currency/:slug is catching errors (#471)

### DIFF
--- a/imports/ui/pages/currencyDetail/commentRender.html
+++ b/imports/ui/pages/currencyDetail/commentRender.html
@@ -1,5 +1,5 @@
 
-<template name="comment">
+<template name="commentRender">
 
   <div class="card padBottom commentParent-{{parentId}} pull-right rounded" style="background-color:#F5F5F7;display:none;width:80%">
       <div class="card-body">

--- a/imports/ui/pages/currencyDetail/commentRender.js
+++ b/imports/ui/pages/currencyDetail/commentRender.js
@@ -1,9 +1,9 @@
 import { Template } from 'meteor/templating'
 import { Features } from '/imports/api/indexDB.js'
 
-import './comment.html'
+import './commentRender.html'
 
-Template.comment.helpers({
+Template.commentRender.helpers({
   alreadyVotedOnComment: function(id) {
       if (_.include(Features.findOne({parentId: id}).appealVoted, Meteor.userId())) {
           return true;
@@ -11,7 +11,7 @@ Template.comment.helpers({
   },
 })
 
-Template.comment.events({
+Template.commentRender.events({
 'click .flag': function() {
 $('#flagModal-' + this._id).modal('show');
 

--- a/imports/ui/pages/currencyDetail/feature.html
+++ b/imports/ui/pages/currencyDetail/feature.html
@@ -54,7 +54,7 @@
   
     {{#if subsCacheReady}}
       {{#each comments}}
-        {{> comment}}
+        {{> commentRender}}
       {{else}}
         {{> empty}}
       {{/each}}

--- a/imports/ui/pages/currencyDetail/feature.js
+++ b/imports/ui/pages/currencyDetail/feature.js
@@ -2,6 +2,7 @@ import { Template } from 'meteor/templating'
 import { Features } from '/imports/api/indexDB.js'
 
 import './feature.html'
+import './commentRender'
 
 Template.feature.onCreated(function() {
   this.autorun(() => {


### PR DESCRIPTION
Solution: Rename the `comment` template into `commentRender` to prevent errors, as `comment` is a field in `comments` which causes issues