### PR TITLE
Problem: /currency/:slug is catching errors (ethereum)

### DIFF
--- a/imports/ui/pages/currencyDetail/currencyInfo.js
+++ b/imports/ui/pages/currencyDetail/currencyInfo.js
@@ -143,13 +143,11 @@ Template.currencyInfo.helpers({
 
   },
   isNull(val, field) {
-
       if (val || val === 0) {
           if (typeof val == "string") {
               return val;
           } else if (typeof val == "object") {
-
-              return val[0].join(", ");
+              return val.length == 1 ? val[0]: val.join(", ");
           } else if (typeof val == "number") {
               return val;
           }


### PR DESCRIPTION
Solution: fixed isNull that expected val to be 2 dimensional array breaking maxCoins field which is an array. #471