### PR TITLE
problem: Icon on winning currency does not link to auction page (#531)

### DIFF
--- a/imports/ui/pages/returnedCurrencies/currency.html
+++ b/imports/ui/pages/returnedCurrencies/currency.html
@@ -1,7 +1,7 @@
 <template name="currency">
   <div class="currency-card">
     <div class="header">
-      <div>{{#if featured}}<i class="fa fa-star"></i>{{/if}} {{currencyName}}</div>
+      <div>{{#if featured}}<a href="/currencyAuction"><i class="fa fa-star"></i></a>{{/if}} {{currencyName}}</div>
       <div>{{currencySymbol}}</div>
     </div>
     <div class="graph">


### PR DESCRIPTION
Solution: Link to the auction page from the icon on the winning currency