### PR TITLE
Problem: No easy way to view applogs collection (#567)

### DIFF
--- a/imports/api/miscellaneous/appLogs.js
+++ b/imports/api/miscellaneous/appLogs.js
@@ -1,3 +1,3 @@
 import { Mongo } from 'meteor/mongo';
 
-export const AppLogs = new Mongo.Collection('AppLogs');
+export const AppLogs = new Mongo.Collection('AppLogs')

--- a/imports/api/miscellaneous/server/publications.js
+++ b/imports/api/miscellaneous/server/publications.js
@@ -1,5 +1,5 @@
 import { Meteor } from 'meteor/meteor'
-import { GraphData, FormData } from '/imports/api/indexDB.js'
+import { GraphData, FormData, AppLogs } from '/imports/api/indexDB.js'
 
 Meteor.publish('graphdata', function graphdataPublication() {
   return GraphData.find();
@@ -7,4 +7,12 @@ Meteor.publish('graphdata', function graphdataPublication() {
 
 Meteor.publish('formdata', function formdataPublication() {
   return FormData.find();
-  });
+  })
+
+Meteor.publish('applogs', (page, perPage) => AppLogs.find({}, {
+	skip: (page - 1) * perPage,
+	limit: perPage,
+	sort: {
+		date: -1
+	}
+}))

--- a/imports/startup/both/routes.js
+++ b/imports/startup/both/routes.js
@@ -47,6 +47,7 @@ if (Meteor.isClient) { // only import them if this code is being executed on cli
   import '../../ui/pages/moderator/flaggedUsers/flaggedUsers'
   import '../../ui/pages/moderator/hashpower/flaggedHashpower'
   import '../../ui/pages/addHashpower/addHashpower.js'
+  import '../../ui/pages/moderator/appLogs/appLogs'
 
   // New Layout doesn't use side Template.dynamic side
   import '../../ui/layouts/mainLayout/mainLayout'
@@ -105,6 +106,20 @@ FlowRouter.route('/currencyAuction', {
   action: (params, queryParams) => {
     BlazeLayout.render('mainLayout', {
       main: 'currencyAuction',
+      //left: 'sideNav'
+    })
+  }
+})
+
+FlowRouter.route('/applogs', {
+  name: 'app-logs',
+  subscriptions: function (params) {
+    this.register('applogs', SubsCache.subscribe('applogs', 1, 50))
+    this.register('users', SubsCache.subscribe('users'))
+  },
+  action: (params, queryParams) => {
+    BlazeLayout.render('mainLayout', {
+      main: 'appLogs',
       //left: 'sideNav'
     })
   }

--- a/imports/ui/components/sideNav/sideNav.html
+++ b/imports/ui/components/sideNav/sideNav.html
@@ -34,6 +34,9 @@
           <li>
             <a href="/transactions/1">All Blockrazor Transactions</a>
           </li>
+          <li>
+            <a href="/applogs">Application logs</a>
+          </li>
         {{/if}}
         <li>
           <a href="/notifications">Notifications

--- a/imports/ui/pages/moderator/appLogs/appLogs.js
+++ b/imports/ui/pages/moderator/appLogs/appLogs.js
@@ -1,0 +1,62 @@
+import { Template } from 'meteor/templating'
+import { AppLogs } from '/imports/api/indexDB'
+import { FlowRouter } from 'meteor/staringatlights:flow-router'
+
+import './appLogs.template.html'
+
+Template.appLogs.onCreated(function() {
+	this.page = 1
+
+	this.autorun(() => {
+		SubsCache.subscribe('applogs', this.page, 100)
+		SubsCache.subscribe('users')
+	})
+
+	this.filter = new ReactiveVar('')
+	this.level = new ReactiveVar('ALL')
+})
+
+Template.appLogs.events({
+	'keyup #js-search': (event, templateInstance) => {
+		event.preventDefault()
+
+		templateInstance.filter.set($(event.currentTarget).val())
+	},
+	'change #js-level': (event, templateInstance) => {
+		event.preventDefault()
+
+		templateInstance.level.set($(event.currentTarget).val())
+	},
+	'click #js-more': (event, templateInstance) => {
+		event.preventDefault()
+
+		Meteor.subscribe('applogs', ++Template.instance().page, 100)
+	}
+})
+
+Template.appLogs.helpers({
+	applogs: () => {
+		return AppLogs.find({
+			level: new RegExp(Template.instance().level.get() === 'ALL' ? '' : Template.instance().level.get(), 'i'),
+			message: new RegExp(Template.instance().filter.get(), 'ig')
+		}, {
+			sort: {
+				date: -1
+			}
+		})
+	},
+	levelColor: function() {
+		return this.level === 'INFO' ? 'green' : this.level === 'WARN' ? 'orange' : 'red'
+	},
+	date: function() {
+		return moment(this.date).format(`${_globalDateFormat} HH:MM:SS`)
+	},
+	user: function() {
+		return (Meteor.users.findOne({
+			_id: this.userId
+		}) || {}).username || 'N\\A'
+	},
+	additionalInfo: function() {
+		return this.additional.connection ? `IP: ${this.additional.connection.clientAddress}` : 'N\\A'
+	}
+})

--- a/imports/ui/pages/moderator/appLogs/appLogs.template.html
+++ b/imports/ui/pages/moderator/appLogs/appLogs.template.html
@@ -1,0 +1,48 @@
+<template name="appLogs">
+    {{#if isModerator}}
+    <h3>Application logs</h3>
+     <div id="logsFilterContainer" class="container"> 
+        <form id="logsFilter" name="logsFilter"> 
+            <div class="row form-items"> 
+                <div class="col-12 form-group"> 
+                    <select class="form-control" id="js-level">
+                        <option>ALL</option>
+                        <option>INFO</option>
+                        <option>WARN</option>
+                        <option>ERROR</option>
+                    </select>
+                    <input id="js-search" name="searchInput" type="text" class="form-control" placeholder="Search logs by message..."> 
+                </div> 
+            </div>
+            <div class="found-result">
+               {{#if filterCount}} Found {{filterCount}} results {{/if}}
+            </div> 
+        </form> 
+    </div>
+    <table class="table">
+        <thead>
+            <tr>
+                <th scope="col">Level</th>
+                <th scope="col">Date &amp; Time</th>
+                <th scope="col">User</th>
+                <th scope="col">Message</th>
+                <th scope="col">Additional info</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{#each applogs}}
+            <tr>
+                <td style="color: {{levelColor}}">{{level}}</td>
+                <td>{{date}}</td>
+                <td>{{user}}</td>
+                <td>{{message}}</td>
+                <td>{{additionalInfo}}</td>
+            </tr>
+            {{/each}}
+        </tbody>
+    </table>
+    <button id="js-more" class="btn btn-action" style="width: 100%">More data?</button>
+    {{else}}
+    <h1>This page is for moderators only.</h1>
+    {{/if}}
+</template>


### PR DESCRIPTION
Solution: Implement a page at `/applogs` where moderators can easily view application logs and filter them by message or level.