### PR TITLE
Problem: Not enough digits after decimal place on currency auction page (#532)

### DIFF
--- a/imports/ui/pages/auctions/currencyAuction.js
+++ b/imports/ui/pages/auctions/currencyAuction.js
@@ -74,7 +74,7 @@ Template.currencyAuction.helpers({
 			_id: (this.options || {}).currency
 		}) || {}).currencyName || ''
 	},
-	fixed: (val) => val.toFixed(2)
+	fixed: (val) => val.toFixed(5)
 })
 
 Template.currencyAuction.events({


### PR DESCRIPTION
Solution: Show 5 decimal places instead of 2 on currency auction page.