### PR TITLE
problem:images cannot be expanded

### DIFF
--- a/imports/ui/pages/problems/problemImages.html
+++ b/imports/ui/pages/problems/problemImages.html
@@ -18,8 +18,8 @@
 </template>
 
 <template name="problemImage">
-  <img src="{{problemImagesDir}}{{thumbnail}}" class="problemImageOpen" data-toggle="modal" data-target="img_{{this}}" id="{{this}}"> 
-  <div class="modal fade" id="img_{{this}}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <img src="{{problemImagesDir}}{{thumbnail}}" class="problemImageOpen" data-toggle="modal" data-target="img_{{_id}}" id="{{_id}}"> 
+  <div class="modal fade" id="img_{{_id}}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-body">

--- a/imports/ui/pages/problems/problemImages.js
+++ b/imports/ui/pages/problems/problemImages.js
@@ -9,6 +9,11 @@ Template.problemImages.helpers({
 })
 
 Template.problemImage.helpers({
+	_id: function() {
+        let img = this.split('.')
+
+        return img[0];
+    },
     thumbnail: function() {
         let img = this.split('.')
 


### PR DESCRIPTION
solution: update helpers to exclude . from the jquery lookup. dots on lookup are not supprted #651