### PR TITLE
problem:full usernames are too big for small screens

### DIFF
--- a/imports/ui/components/topNav/topNav.html
+++ b/imports/ui/components/topNav/topNav.html
@@ -11,7 +11,7 @@
         {{#if currentUser}}
         <div class="dropdown show">
           <a class="btn dropdown-toggle text-white" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            {{currentUser.username}}
+            <span class="d-none d-sm-block">{{currentUser.username}}</span><span class="d-sm-none"><i class="fa fa-user text-white"></i></span>
           </a>      
           <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
             <a class="dropdown-item" href="/profile/{{slug}}">My profile</a>


### PR DESCRIPTION
solution: add responsive css classes to hide and show dom elements based on screensize #626. 

For those interested in how to handle dom manipulation based on screensize. Checkout the following [Bootstrap 4 documentation ](https://getbootstrap.com/docs/4.0/utilities/display/).