### PR TITLE
Problem: No currency comparison prices (#627)

### DIFF
--- a/imports/ui/pages/compareCurrencies/compareCurrencies.html
+++ b/imports/ui/pages/compareCurrencies/compareCurrencies.html
@@ -27,6 +27,18 @@
                                 {{/each}}
                             </tr>
                             <tr>
+                                <td>Comparison Price (Circulation)</td>
+                                {{#each comparedCurrencies}}
+                                <td style="color: {{color}};">{{cpc}}$</td>
+                                {{/each}}
+                            </tr>
+                            <tr>
+                                <td>Comparison Price (Total)</td>
+                                {{#each comparedCurrencies}}
+                                <td style="color: {{color}};">{{cpt}}$</td>
+                                {{/each}}
+                            </tr>
+                            <tr>
                                 <td style="text-align: center" colspan="{{colspan}}">Features</td>
                             </tr>
                             {{#each top3}}

--- a/imports/ui/pages/compareCurrencies/compareCurrencies.js
+++ b/imports/ui/pages/compareCurrencies/compareCurrencies.js
@@ -330,7 +330,9 @@ Template.compareCurrencies.helpers({
 				maxCoins: 1,
 				hashpower: 1,
 				slug: 1,
-				price: 1
+				price: 1,
+				cpt: 1,
+				cpc: 1
 			}
 		}).fetch()
 

--- a/imports/ui/pages/currencyDetail/currencyInfo.html
+++ b/imports/ui/pages/currencyDetail/currencyInfo.html
@@ -78,6 +78,24 @@
             </div>
             <div class="col-md-4">
               <div class="card card-body">
+                <div class="title">Price</div>
+                <div class="value" id="price">{{isNull price 'price'}}$</div>
+              </div>
+            </div>
+            <div class="col-md-4">
+              <div class="card card-body">
+                <div class="title">Comparison Price (Circulation)</div>
+                <div class="value" id="cpc">{{isNull cpc 'cpc'}}$</div>
+              </div>
+            </div>
+            <div class="col-md-4">
+              <div class="card card-body">
+                <div class="title">Comparison Price (Total)</div>
+                <div class="value" id="cpt">{{isNull cpt 'cpt'}}$</div>
+              </div>
+            </div>
+            <div class="col-md-4">
+              <div class="card card-body">
                 <div class="title">Market Cap</div>
                 <div class="value" id="marketCap">{{isNull marketCap 'marketCap'}}</div>
               </div>

--- a/server/API_requests/github.js
+++ b/server/API_requests/github.js
@@ -6,7 +6,7 @@ import { log } from '../main'
 SyncedCron.add({
   name: 'Update from CoinMarketCap',
   schedule: function(parser) {
-    return parser.text('every 10 minutes');
+    return parser.text('every 5 minutes');
   },
   job: function() {
     Meteor.call('updateMarketCap');
@@ -109,20 +109,21 @@ var allcurrencies = Currencies.find({}, { sort: { createdAt: -1 }}).fetch();
         for (var key in result.data) {
           for (var currency in allcurrencies) {//i = 0; i < Currencies.find({}, { sort: { createdAt: -1 }}).count(); i++) {
             if (result.data[key].name.toLowerCase() == allcurrencies[currency].currencyName.toLowerCase() || result.data[key].name == allcurrencies[currency].currencySymbol) {
-            console.log("Updating: " + allcurrencies[currency].currencyName);
-            Currencies.upsert(allcurrencies[currency]._id,
-            {
-              $set: {
-                marketCap: Math.round(result.data[key].market_cap_usd),
-                circulating: Math.round(result.data[key].available_supply),
-                price:   (result.data[key].market_cap_usd / result.data[key].available_supply).toFixed(2)//.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")
-              }
+              console.log("Updating: " + allcurrencies[currency].currencyName)
 
-            });
+              let price = result.data[key].market_cap_usd / result.data[key].available_supply
+
+              Currencies.upsert(allcurrencies[currency]._id,
+              {
+                $set: {
+                  marketCap: Math.round(result.data[key].market_cap_usd),
+                  circulating: Math.round(result.data[key].available_supply),
+                  price: price.toFixed(2),//.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")
+                  cpc: ((result.data[key].available_supply / 100000000) * price).toFixed(2),
+                  cpt: (((allcurrencies[currency].maxCoins || 0) / 100000000) * price).toFixed(2), // just to be safe
+                }
+              })
             }
-
-
-
           }
           // Currencies.insert({
           // currencyName: result.data[key].name,


### PR DESCRIPTION
Solution: Calculate currency comparison prices (CPC and CPT) when updating values for market cap and circulating coins. Show CPC and CPT on 'currency compare' page and on the 'currency detail' page.