### PR TITLE
Problem: New currency bounty does not reset until new currency approved (#718)

### DIFF
--- a/imports/ui/pages/bounties/bounties.js
+++ b/imports/ui/pages/bounties/bounties.js
@@ -36,7 +36,7 @@ Template.bounties.onCreated(function(){
 
   Meteor.call('getLastCurrency', (err, data) => {
     let times = this.times.get()
-    times['new-currency'] = data.approvedTime
+    times['new-currency'] = data.createdAt
     this.times.set(times)
   })
 


### PR DESCRIPTION
Solution: Reset the new currency bounty when a new currency is added, not when it's approved.