### PR TITLE
Problem: Use of slugs as unique id for usernames causes problems when two people have same name (#747)

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -60,12 +60,16 @@ Template.registerHelper('isDeveloper', () => {
 
 
 Template.registerHelper('slugify', function(author) {
-  var author = author.toLowerCase()
+    SubsCache.subscribe('user', author)
+
+    return (Meteor.users.findOne({
+        username: author
+    }) || {}).slug
+  /*var author = author.toLowerCase()
   let slug = author.replace(/'/g, '').replace(/[^0-9a-z-]/g, '-').replace(/\-\-+/g, '-').replace(/^-+/, '').replace(/-+$/, '');
 
-  return slug;
-
-});
+  return slug;*/
+})
 
 Template.registerHelper('relativeTime', function(date) {
   var timePassed = moment(date).fromNow();

--- a/imports/api/users/server/publications.js
+++ b/imports/api/users/server/publications.js
@@ -93,7 +93,9 @@ import { UserData, ProfileImages } from '/imports/api/indexDB.js'
 				slug: slug
 			}, {
 				_id: slug
-			}]
+			}, {
+        username: slug
+      }]
 		}, {
 			fields: {
 				username: 1,


### PR DESCRIPTION
Solution: In `slugify` helper, instead of slugifying author's name, subscribe to user data and get the slug from the database.