### PR TITLE
problem:no reason shown for transactions

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -65,10 +65,7 @@ Template.registerHelper('slugify', function(author) {
     return (Meteor.users.findOne({
         username: author
     }) || {}).slug
-  /*var author = author.toLowerCase()
-  let slug = author.replace(/'/g, '').replace(/[^0-9a-z-]/g, '-').replace(/\-\-+/g, '-').replace(/^-+/, '').replace(/-+$/, '');
 
-  return slug;*/
 })
 
 Template.registerHelper('relativeTime', function(date) {
@@ -97,4 +94,38 @@ Template.registerHelper('profilePicture', (pic) => {
     } else {
         return '/images/noprofile.png'
     }
+});
+
+
+Template.registerHelper('transactionTypes', (transaction) => {
+
+  if(!_validTransactionTypes.includes(transaction)){
+    throw new Meteor.Error('error', 'Invalid Transaction Type Used')
+  }else{
+
+    switch (transaction) {
+        case 'topCommentReward':
+            return 'Top Comment Reward'
+            break;
+        case 'hashReward':
+            return 'Hash Reward'
+            break;
+        case 'bountyReward':
+            return 'Bounty Reward'
+            break;
+        case 'problemReward':
+            return 'Problem Reward'
+            break;
+        case 'createCoinReward':
+            return 'Create Coin Reward'
+            break;
+        case 'cheating':
+            return 'Cheating Penalty'
+            break;
+        case 'anwserQuestion':
+            return 'Question Reward'
+            break;
+
+    }
+  }
 });

--- a/imports/api/wallet/server/methods.js
+++ b/imports/api/wallet/server/methods.js
@@ -221,7 +221,8 @@ Meteor.methods({
 				time: 1,
 				owner: 1,
 				from: 1,
-				amount: 1
+				amount: 1,
+				rewardType:1
 			},
 			skip: (page - 1) * 10,
 			limit: 10 // show 10 transactions per page

--- a/imports/ui/pages/transactions/transactions.html
+++ b/imports/ui/pages/transactions/transactions.html
@@ -22,6 +22,7 @@
                 <th scope="col">From</th>
                 <th scope="col">To</th>
                 <th scope="col">Amount</th>
+                <th scope="col">Type</th>
             </tr>
         </thead>
         <tbody>
@@ -31,6 +32,7 @@
                         <td>{{from}}</td>
                         <td>{{to}}</td>
                         <td><span style="color: {{color}}">{{amount}}</span> KZR</td>
+                        <td>{{transactionTypes rewardType}}</td>
                     </tr>
                 {{else}}
                     {{> empty}}


### PR DESCRIPTION
solution: add descriptive transaction type name in the grid, global helper created to reuse code on other pages #748