### PR TITLE
Problem: [/] first coins on / route don't look complete (#780)

### DIFF
--- a/imports/ui/components/radarGraph.js
+++ b/imports/ui/components/radarGraph.js
@@ -17,6 +17,8 @@ const quality = (currency) => {
   return ((currency.eloRanking || 0) - eloMinElo) / ((eloMaxElo - eloMinElo) || 1)
 }
 
+export { quality }
+
 Template.radarGraph.onCreated(function () {
   var self = this
   self.autorun(function(){

--- a/imports/ui/pages/returnedCurrencies/returnedCurrencies.js
+++ b/imports/ui/pages/returnedCurrencies/returnedCurrencies.js
@@ -5,6 +5,8 @@ import scrollmagic from 'scrollmagic';
 import './returnedCurrencies.html'
 import './currency.js'
 
+import { quality } from '../../components/radarGraph'
+
 Template.returnedCurrencies.onCreated(function bodyOnCreated() {
   var self = this
   self.autorun(function(){
@@ -121,7 +123,15 @@ Template.returnedCurrencies.helpers({
                 cpt: 1,
                 price: 1
               }
-             });
+             }).fetch().sort((i1, i2) => {
+              if (i1.featured) { // take fetured currencies into account
+                return -1
+              } else if (i2.featured) {
+                return 1
+              }
+              
+              return quality(i2) - quality(i1)
+             })
 
     },
     filterCount() {


### PR DESCRIPTION
Solution: Sort cryptocurrencies on the front page by data quality rank (of course, featured ones still come first)