### PR TITLE
Problem: undefered call to set user preference for open/close sidebar

### DIFF
--- a/imports/api/users/client/users.js
+++ b/imports/api/users/client/users.js
@@ -1,9 +1,12 @@
 Meteor.startup(() => {
   //functions to call before logout such that userId is still availabe
+  //prevents duplicate function names in hook
   let hookedLogout = []
 
   Meteor.beforeLogout = cb => {
+    if (hookedLogout.filter(x=>x.name==cb.name).length==0){
     hookedLogout.push(cb)
+    }
   }
   
   const logout = Meteor.logout
@@ -12,7 +15,6 @@ Meteor.startup(() => {
     hookedLogout.forEach(x => {
       x()
     })
-    
     logout()
   }
 })

--- a/imports/api/users/methods.js
+++ b/imports/api/users/methods.js
@@ -3,6 +3,7 @@ import { UserData } from '/imports/api/indexDB.js'
 
 Meteor.methods({
   sidebarPreference: function(value) {
+    console.log(value, "value for sidebar")
     return UserData.update({
       _id: this.userId
     }, {


### PR DESCRIPTION
Solution: the logic is ironcland, the unload event and meteor.method don't play together. reverted to saving all the time. #565