### PR TITLE
problem: hashpower API bounties not shown unless logged in. issue #887

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,5 +6,6 @@ Gregory Mendoza (gregmendgreg@gmail.com)
 Zhan Ishzhanov (jey.and.key@gmail.com)
 Madan Bhandari (madan.kbh@gmail.com)
 Samuel Ralak (thesamuelralak@gmail.com)
+Chamidu Supeshala (chamidusupeshala@gmail.com)
 
 ----Please add your name above this line with your first pull request----

--- a/imports/ui/pages/bounties/bounties.js
+++ b/imports/ui/pages/bounties/bounties.js
@@ -115,10 +115,10 @@ Template.bounties.onCreated(function(){
         currentlyAvailable: !(b && b.expiresAt > Date.now()),
         currentUsername: (b && b.expiresAt > Date.now()) && (Meteor.users.findOne({
           _id: b.userId
-        }) || {}).username || '',
-		currentUserId: (b && b.expiresAt > Date.now()) && (Meteor.users.findOne({
+        }).username || ''),
+        currentUserId: (b && b.expiresAt > Date.now()) && (Meteor.users.findOne({
           _id: b.userId
-	  	}) || {})._id || '',
+        })._id || ''),
         url: `/currency/${i.slug}`,
         creationTime: i.createdAt,
         time: 7200000.0,


### PR DESCRIPTION
solution: 

small logic change to continue even when users _id and name not available. this will display hashpower API bounties also to the guests. when a guest trying to start taking a bounty, he/she will be redirected to the login page.