### PR TITLE
Problem: Toaster box for message alert is displayed behind navigation bar.  issue #898

### DIFF
--- a/imports/ui/components/topNav/topNav.scss
+++ b/imports/ui/components/topNav/topNav.scss
@@ -1,5 +1,5 @@
 #topnav{
-  z-index: 2147483647 !important;
+  z-index: 2147483646 !important;
   position: fixed;
   top: 0;
   left: 0;

--- a/imports/ui/layouts/mainLayout/mainLayout.scss
+++ b/imports/ui/layouts/mainLayout/mainLayout.scss
@@ -12,3 +12,7 @@
   min-height: 100vh;
   max-height: 100%;
 }
+
+.top-nav .s-alert-box{
+  z-index: 2147483647 !important;
+}


### PR DESCRIPTION
Solution: Change z-index of alert box so that it can be displayed above navigation bar.