### PR TITLE
problem: [/] warning modal is displayed under navbar #911

### DIFF
--- a/imports/ui/layouts/mainLayout/mainLayout.scss
+++ b/imports/ui/layouts/mainLayout/mainLayout.scss
@@ -16,3 +16,7 @@
 .top-nav .s-alert-box{
   z-index: 2147483647 !important;
 }
+
+.modal {
+  z-index: 2147483648 !important; /** every modal's z-index should be grater than the nav bar **/
+}


### PR DESCRIPTION
solution: reduced z-index of modal than the z-index of navbar
(applied for every modal commonly, because some other modals also appeared below navbar)