### PR TITLE
Problem: userStats observeChanges triggering on all instances #882

### DIFF
--- a/imports/api/users/usersStats.js
+++ b/imports/api/users/usersStats.js
@@ -4,36 +4,43 @@ import { UserPresence } from 'meteor/socialize:user-presence';
 export const UsersStats = new Mongo.Collection('usersStats')
 
 if (Meteor.isServer){
-Meteor.startup(function(){
-  UsersStats.remove({})
   var stats = UsersStats.find().fetch()
   if (stats.length != 2){
-    if (stats.find(x=>x._id == "connected") == undefined){
-      UsersStats.insert({_id: "connected", connected: 0})
-    } 
-    if (stats.find(x=>x._id == "created") == undefined) {
-      UsersStats.insert({_id: "created", created: Meteor.users.find().count()})
-    }
+    UsersStats.remove({})
+    UsersStats.insert({_id: "connected", connected: 0, userIds: []})
+    UsersStats.insert({_id: "created", created: Meteor.users.find().count()})
   }
-})
 
+//used to prevent edits to connected field parsed from userIds field on every running instance when observer triggers
+var connectedLength = new Set(UsersStats.findOne("connected", {fields: {userIds: 1}}).userIds)
 
 UsersStats.find({_id: "connected"}, {fields: {userIds: 1}}).observeChanges({
   changed(id, fields){
-    UsersStats.update("connected", {$set: {connected: fields.userIds.length}})
-    return 
+    if (connectedLength.size == fields.userIds.length){
+    } else {
+      connectedLength = new Set(fields.userIds)
+    }
+    return  
   }
 })
 
 //will fire several times per user thus requires observer
 UserPresence.onUserOnline(function(userId, connection){
-  // console.log(userId, connection.id)
-  UsersStats.update("connected", {$addToSet: {userIds: userId}})
+  var len = connectedLength.size
+  connectedLength.add(userId)
+  if (len != connectedLength.size){
+    UsersStats.update("connected", {$addToSet: {userIds: userId}, $inc: {connected: 1}})
+  }
 });
 
 UserPresence.onUserOffline(function (userId) {
-  console.log(userId, "offline")
-  UsersStats.update("connected", {$pull: {userIds: userId}})
+  var len = connectedLength.size
+  connectedLength.delete(userId)
+  console.log("init", connectedLength, len, connectedLength.size)
+  if (len != connectedLength.size){
+    console.log("removing", len)
+    UsersStats.update("connected", {$pull: {userIds: userId}, $inc: {connected: -1}})
+  }
 });
 
 //called in Accounts.onCreated hook in users.js


### PR DESCRIPTION
Solution: used new Set() to diff if userOnline callback trigger erroneusly, and made observeChanges compare lengths with on memory and database before updating connected field. #882