### PR TITLE
Problem: add new currency last reward incorrect #951

### DIFF
--- a/imports/api/bounties/server/methods.js
+++ b/imports/api/bounties/server/methods.js
@@ -90,6 +90,7 @@ Meteor.methods({
     }, {
       $set: {
         completed: true,
+        completedAt: Date.now(),
         id: id
       }
     })

--- a/imports/ui/pages/bounties/bounties.js
+++ b/imports/ui/pages/bounties/bounties.js
@@ -141,7 +141,7 @@ Template.bounties.onCreated(function(){
     union.map((x, i)=>{
       // return this.LocalBounties.insert(x)
       //note the field projection
-      var lastCompletedBounty = Bounties.findOne({type: x._id, completed: true, currentReward: {$exists: true}}, {sort: {completedAt: -1}, fields: {currentReward: 1, completedAt: 1, currentUsername: 1}})
+      var lastCompletedBounty = Bounties.findOne({type: x._id, completed: true, currentReward: {$exists: true}}, {sort: {completedAt: -1, expiresAt: -1}, fields: {currentReward: 1, completedAt: 1, currentUsername: 1}})
       //preserves previous sort operation
       x.sort = i
       var copy = this.LocalBounties.findOne(x._id)

--- a/imports/ui/pages/bounties/bountyRender.html
+++ b/imports/ui/pages/bounties/bountyRender.html
@@ -30,8 +30,9 @@
         </div>
         <div class="col-sm-4">
           <h5 class="float-right my-4 my-sm-0">
-            <span class="mr-2">{{reward}}</span>KZR
-            <span class="mr-2">{{previousReward}} {{currentUsername}}</span>KZR
+            <span class="mr-2 float-right">{{reward}} &nbsp;KZR</span>
+            <br/>
+            {{#if previousReward}}<span class="mr-2 float-right" style="font-size:12px;color:#999">Last Reward: {{previousReward}} KZR</span>{{/if}}
           </h5>
         </div>
       </div>


### PR DESCRIPTION
Solution: corrected last reward value for add new currency bounty

Note:  previously the bounty completion timestamp is not being saved in the DB. I have corrected it to save the 'completedAt' timestamp in the DB for newly completing bounties.

However as the previously completed bounties not having a completion timestamp, for selecting last bounty, a priority sort is used.
With that, the sorting will be performed first with 'completedAt' field and if there is no such field (for old bounties) the sorting will be performed with 'expiresAt' field.
