### PR TITLE
Problem: Community and wallet rating questions cannot be rejected by moderators (#961)

### DIFF
--- a/imports/api/communities/methods.js
+++ b/imports/api/communities/methods.js
@@ -1,5 +1,5 @@
 import { Meteor } from 'meteor/meteor'
-import { UserData, Currencies, Communities, developmentValidationEnabledFalse } from '/imports/api/indexDB'
+import { UserData, Currencies, Communities, developmentValidationEnabledFalse, Ratings } from '/imports/api/indexDB'
 import SimpleSchema from 'simpl-schema'; //you must import SimpleSchema 
 
 
@@ -44,32 +44,4 @@ export const saveCommunity = new ValidatedMethod({
             throw new Meteor.Error('Error.', 'You have to be logged in.')
         }
     }
-});
-
-
-Meteor.methods({
-
-    flagCommunityImage: function(imageId) {
-        if(!this.userId){throw new Meteor.Error('error', 'please log in')};
-
-        Communities.update(imageId, {
-            $addToSet: {flaglikers: Meteor.userId()},
-            $inc: {flags: 1}
-        })
-
-        Meteor.call('userStrike', Meteor.userId(), 'bad-wallet', 's3rv3r-only', (err, data) => {}) // user earns 1 strike here
-    },
-
-    approveCommunityImage: function(imageId) {
-        if(!this.userId){throw new Meteor.Error('error', 'please log in')};
-        if(Communities.findOne({_id: imageId}).createdBy == this.userId) {
-            throw new Meteor.Error('error', "You can't approve your own item.")
-        };
-
-        Communities.update(imageId, {
-            $set: {approved: true, approvedBy: this.userId},
-            $inc: {likes: 1}
-        });
-    }
-
-});
+})

--- a/imports/ui/pages/communities/communities.js
+++ b/imports/ui/pages/communities/communities.js
@@ -130,42 +130,6 @@ Template.communities.helpers({
 
         return `You have ${Math.round((bounty.expiresAt - Template.instance().now.get())/1000/60)} minutes to complete the bounty for ${Number(bounty.currentReward).toFixed(2)} KZR.`;
     },
-    alreadyAdded: () => {
-        let alreadyAdded = _.uniq(_.flatten(Ratings.find({
-            $or: [{
-                owner: Meteor.userId(),
-                catagory: 'community'
-            }, {
-                owner: Meteor.userId(),
-                context: 'community'
-            }]
-        }).fetch().map(i => [i.currency0Id,i.currency1Id])))
-
-        return Currencies.find({
-            _id: {
-                $in: alreadyAdded
-            }
-        })
-    },
-    currencies: () => {
-        let alreadyAdded = _.uniq(_.flatten(Ratings.find({
-            $or: [{
-                owner: Meteor.userId(),
-                catagory: 'community'
-            }, {
-                owner: Meteor.userId(),
-                context: 'community'
-            }]
-        }).fetch().map(i => [i.currency0Id,i.currency1Id])))
-
-        return Currencies.find({
-            _id: {
-                $nin: alreadyAdded
-            },
-            currencyName: new RegExp(Template.instance().name.get(), 'ig'),
-            currencySymbol: new RegExp(Template.instance().symbol.get(), 'ig')
-        })
-    },
     questions: () => {
         return Ratings.findOne({
             $or: [{

--- a/imports/ui/pages/moderator/moderatorDash/approveCommunityImage.js
+++ b/imports/ui/pages/moderator/moderatorDash/approveCommunityImage.js
@@ -2,22 +2,31 @@ import { Template } from 'meteor/templating';
 import './approveCommunityImage.html'
 
 Template.approveCommunityImage.events({
-  'click #reject': function(event){
-    Meteor.call('flagWalletImage', this._id);
-    console.log(this._id);
+  'click #reject': function(event) {
+    Meteor.call('flagCommunityImage', this._id, (err, data) => {
+      if (!err) {
+        sAlert.success('Rejected.')
+      } else {
+        sAlert.error(err.reason)
+      }
+    })
   },
-  'click #approve': function(event){
-    Meteor.call('approveCommunityImage', this._id);
+  'click #approve': function(event) {
+    Meteor.call('approveCommunityImage', this._id, (err, data) => {
+      if (!err) {
+        sAlert.success('Approved.')
+      } else {
+        sAlert.error(err.reason)
+      }
+    })
   }
-});
+})
 
 Template.approveCommunityImage.helpers({
   _communityUploadDirectoryPublic(){
     return _communityUploadDirectoryPublic
   },
-  display() {
-    if(_.include(this.flaglikers, Meteor.userId())) {
-      return "none";
-    } else {return "flex"}
+  display: function() {
+    return !this.approved ? 'flex' : 'none' 
   }
 })

--- a/imports/ui/pages/moderator/moderatorDash/approveWalletImage.js
+++ b/imports/ui/pages/moderator/moderatorDash/approveWalletImage.js
@@ -2,19 +2,28 @@ import { Template } from 'meteor/templating';
 import './approveWalletImage.html'
 
 Template.approveWalletImage.events({
-  'click #reject': function(event){
-    Meteor.call('flagWalletImage', this._id);
-    console.log(this._id);
+  'click #reject': function(event) {
+    Meteor.call('flagWalletImage', this._id, (err, data) => {
+      if (!err) {
+        sAlert.success('Rejected.')
+      } else {
+        sAlert.error(err.reason)
+      }
+    })
   },
-  'click #approve': function(event){
-    Meteor.call('approveWalletImage', this._id);
+  'click #approve': function(event) {
+    Meteor.call('approveWalletImage', this._id, (err, data) => {
+      if (!err) {
+        sAlert.success('Approved.')
+      } else {
+        sAlert.error(err.reason)
+      }
+    })
   }
-});
+})
 
 Template.approveWalletImage.helpers({
-  display() {
-    if(_.include(this.flaglikers, Meteor.userId())) {
-      return "none";
-    } else {return "flex"}
+  display: function() {
+    return !this.approved ? 'flex' : 'none' 
   }
 })

--- a/server/methods/elorankings.js
+++ b/server/methods/elorankings.js
@@ -1,4 +1,4 @@
-import { EloRankings, Ratings, RatingsTemplates, Currencies, GraphData, Communities, Bounties } from '/imports/api/indexDB.js';
+import { EloRankings, Ratings, RatingsTemplates, Currencies, GraphData, Communities, Bounties, WalletImages } from '/imports/api/indexDB.js';
 import { log } from '../main'
 
 SyncedCron.add({
@@ -231,6 +231,30 @@ Meteor.methods({
 
         if (bounty) {
             return i.answeredAt > bounty.createdAt && i.answeredAt < bounty.expiresAt // question was answered in this time period 
+        }
+
+        if (i.catagory === 'community' || i.context === 'community') {
+            let community = Communities.find({
+                $or: [{
+                    currencyId: i.currency0Id
+                }, {
+                    currencyId: i.currency1Id
+                }]
+            }).fetch()
+
+            return !community.length || community.every(i => !!i.approved) // don't process communities that haven't been approved already
+        }
+
+        if (i.catagory === 'wallet' || i.context === 'wallet') {
+            let wallet = WalletImages.find({
+                $or: [{
+                    currencyId: i.currency0Id
+                }, {
+                    currencyId: i.currency1Id
+                }]
+            }).fetch()
+
+            return !wallet.length || wallet.every(i => !!i.approved) // don't process wallets that haven't approved
         }
 
         return true


### PR DESCRIPTION
Solution: Implement a way for moderators to reject invalid wallet and community images, and purge user's credit and ELO rankings associated with that particular image. Also, don't process community and wallet ELO rankings before images are approved to prevent incorrect ELO scores.