### PR TITLE
problem: currency comparison typeahead is broken #996

### DIFF
--- a/imports/ui/components/typeahead.js
+++ b/imports/ui/components/typeahead.js
@@ -63,7 +63,7 @@ Template.typeahead.onCreated(function () {
   this.data.focus = this.data.focus === undefined? false: this.data.focus
   this.data.autoFocus = this.data.autoFocus === undefined? false: this.data.autoFocus
   this.data.quickEnter = this.data.quickEnter === undefined? true: this.data.quickEnter
-  this.data.noneFound = this.data.noneFound === undefined? false: this.data.noneFound
+  this.data.noneFound = this.data.noneFound === undefined? function(templ, eleId){ return 'no result found' } : this.data.noneFound
 
   var props = this.data
   var templ = props.template
@@ -104,7 +104,7 @@ Template.typeahead.onCreated(function () {
 			limit: props.limit,
       source: currySearch(templ, this),
       templates: {
-        empty: 'no result found'
+        empty: this.data.noneFound(templ, this.data.id),
       }
 		}
 	

--- a/imports/ui/components/typeahead.js
+++ b/imports/ui/components/typeahead.js
@@ -92,7 +92,6 @@ Template.typeahead.onCreated(function () {
       children.map(el => frag.appendChild(el))
       return frag
     }
-    console.log(createElement(this.data.noneFound()))
 
 		var option1 = {
 			hint: true,
@@ -105,7 +104,7 @@ Template.typeahead.onCreated(function () {
 			limit: props.limit,
       source: currySearch(templ, this),
       templates: {
-        empty: this.data.noneFound(templ, this.data.id),
+        empty: 'no result found'
       }
 		}
 	


### PR DESCRIPTION
Solution: default handler for handle no match found incident, when no handler provided by the template