### PR TITLE
Problem: duplicate subscription calls + navigation speed

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -50,8 +50,7 @@ staringatlights:flow-router
 fourseven:scss
 gwendall:hovercard
 babrahams:constellation
-ccorcos:subs-cache 
-meteorhacks:subs-manager
+blockrazor:subscache-c4
 practicalmeteor:mocha
 natestrauser:x-editable-bootstrap
 mrt:combodate

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -22,11 +22,11 @@ binary-heap@1.0.10
 blaze@2.3.2
 blaze-html-templates@1.1.2
 blaze-tools@1.0.10
+blockrazor:subscache-c4@2.0.2
 boilerplate-generator@1.3.1
 caching-compiler@1.1.9
 caching-html-compiler@1.1.2
 callback-hook@1.0.10
-ccorcos:subs-cache@0.9.4
 cfs:graphicsmagick@0.0.18
 check@1.2.5
 chuangbo:cookie@1.1.0
@@ -88,7 +88,6 @@ meteor@1.8.2
 meteor-base@1.2.0
 meteorhacks:meteorx@1.4.1
 meteorhacks:picker@1.0.3
-meteorhacks:subs-manager@1.6.4
 meteortoys:toykit@4.0.1
 minifier-css@1.2.16
 minifier-js@2.2.2

--- a/imports/startup/both/routes.js
+++ b/imports/startup/both/routes.js
@@ -1,19 +1,17 @@
 import {FlowRouter} from 'meteor/staringatlights:flow-router';
 import {FastRender} from 'meteor/staringatlights:fast-render'
 // import {SubsCache} from 'meteor/ccorcos:subs-cache'
-import {SubsManager} from 'meteor/meteorhacks:subs-manager'
+import {SubsCache as Sub} from 'meteor/blockrazor:subscache-c4'
 
-// SubsCache = new SubsManager({
-//   cacheLimit: 30,
-//   // expireIn will stop subscription after timer ends regardless if it's actually still being rendered or not
-//   expireIn: 5555555555555555555555555555555555,
-// }); // is 5 minutes, and 10 subs by default for subs-cache not manager packages
+SubsCache = new Sub(5, 10); // is 5 minutes, and 10 subs by default for subs-cache not manager packages
 
-SubsCache = Meteor
-SubsCache.ready = function() {return true}
+console.log(1, SubsCache)
+
+// SubsCache = Meteor
+// SubsCache.ready = function() {return true}
 if (Meteor.isClient) { // only import them if this code is being executed on client side
     //ubiquitous components
-    import '../../ui/components/loading'
+    import '../../ui/components/loading.js'
     import '../../ui/components/empty.html'
 
     //pages
@@ -66,8 +64,6 @@ if (Meteor.isClient) { // only import them if this code is being executed on cli
   import '../../ui/layouts/mainLayout/mainLayout'
 
   //Stylesheet
-  //is in client folder
-  // import '/imports/ui/stylesheets/lux.min.css';
 } else {
   SubsCache = Meteor
 }


### PR DESCRIPTION
Solution: Use subs-manager within templates and router, or delete template subscriptions which would be an anti-pattern. I intend to set a generic timer of a minute for cache (subscription still running) termination. #333