### PR TITLE
Problem: calculateReward in [/bounties] runs a lot and everywhere

### DIFF
--- a/imports/ui/pages/bounties/bountyRender.js
+++ b/imports/ui/pages/bounties/bountyRender.js
@@ -4,7 +4,7 @@ import { FlowRouter } from 'meteor/staringatlights:flow-router';;
 import Cookies from 'js-cookie';
 
 import './bountyRender.html'
-import { calculateReward } from './bounties'
+import { LocalBounties } from './bounties'
 import '/imports/ui/components/global/globalHelpers'
 
 Template.bountyRender.onCreated(function(){
@@ -90,7 +90,8 @@ Template.bountyRender.helpers({
     }
   },
   reward: function () {
-    return calculateReward.call(this, Session.get('now'))
+    var b = LocalBounties.findOne(this._id, {fields: {reward: 1}}).reward
+    return b.toFixed(6)
   }
 });
 


### PR DESCRIPTION
Solution: In bounties.js split away calculateReward to operate on LocalBounties local collection with this.ids.get() filter, and adjust bounties helper query to sort by calculatedReward value of document. Ideally calculateReward would be set to 0 in fields projection in helper that renders the list in bounty.js so that list doesn't rerender unless the sort order changes, and bountyRender having a separate helper that queries for that field to show it in that template. #791 