### PR TITLE
Problem: sidebar preference updates always write to DB

### DIFF
--- a/imports/api/users/methods.js
+++ b/imports/api/users/methods.js
@@ -2,9 +2,13 @@ import { Meteor } from 'meteor/meteor'
 import { UserData } from '/imports/api/indexDB.js'
 
 Meteor.methods({
-  sidebarPreference: function(value) {
-    console.log(value, "value for sidebar")
-    return UserData.update({
+  sidebarPreference: function(value, valueOnRecord) {
+    //ignore request if valueOnRecord provided from beforeUnload hook that will not care if operations that decide if method should be called actually finish
+    if (valueOnRecord && valueOnRecord == value){
+      return
+    }
+    
+    UserData.update({
       _id: this.userId
     }, {
       $set: {


### PR DESCRIPTION
Solution: Publications didn't work. Wind up using unload event in meteor.startup writing short function as callback since it appears the function didn't manage to finish running before. #989