### PR TITLE
Problem: Clicking logo does not direct to home route (#1105)

### DIFF
--- a/imports/api/utilities.js
+++ b/imports/api/utilities.js
@@ -298,7 +298,9 @@ export class LocalizableCollection extends Mongo.Collection {
             return super.findOne(selector, projection)
           } else {
             var res = super.findOne(selector, projection)
+            if (res) {
               this.local.update(res._id, res)
+            }
               return res
           }
         } else {


### PR DESCRIPTION
Solution: Check whether result is defined in LocalizableCollection's `findOne` method in order to fix the issue.