### PR TITLE
Problem: Winning currency displayed at same time as "put your coin here" item (#1164)

### DIFF
--- a/imports/ui/pages/returnedCurrencies/returnedCurrencies.js
+++ b/imports/ui/pages/returnedCurrencies/returnedCurrencies.js
@@ -63,7 +63,7 @@ Template.returnedCurrencies.onCreated(function bodyOnCreated() {
   })
 
   this.autorun(() => {
-    this.noFeatured.set(!Currencies.findOne({
+    this.noFeatured.set(!Currencies.findOneLocal({
       featured: true
     }))
   })


### PR DESCRIPTION
Solution: Query the local `Currencies` collection instead of the global one to determine whether to show the 'put your coin here' item.