### PR TITLE
Problem: Time displayed on auctions is absolute (#1151)

### DIFF
--- a/imports/ui/pages/auctions/allAuctions.js
+++ b/imports/ui/pages/auctions/allAuctions.js
@@ -67,13 +67,16 @@ Template.allAuctions.helpers({
     },
     fixed: (val) => val.toFixed(6),
     time: function() {
-        return moment(this.options.timeout).format(`${_globalDateFormat} HH:mm`)
+        return moment(this.options.timeout).fromNow()
     },
     status: function() {
         return this.closed ? 'CLOSED' : 'OPEN'
     },
     statusColor: function() {
         return this.closed ? 'red' : 'green'
+    },
+    verb: function() {
+        return this.closed ? 'Ended' : 'Ends'
     }
 })
 

--- a/imports/ui/pages/auctions/allAuctions.template.html
+++ b/imports/ui/pages/auctions/allAuctions.template.html
@@ -36,7 +36,7 @@
                             <td>{{options.baseCurrency}}</td>
                             <td>{{options.acceptedCurrency}}</td>
                             <td>{{fixed options.amount}} {{options.baseCurrency}}</td>
-                            <td>{{time}}</td>
+                            <td>{{verb}} {{time}}</td>
                             <td style="color: {{statusColor}}">{{status}}</td>
                             <td>{{highest}} {{options.acceptedCurrency}} {{#if needsUSD options.acceptedCurrency}}{{#if USDprice options.acceptedCurrency highest}}({{USDprice options.acceptedCurrency highest}} USD){{/if}}{{/if}}</td>
                             <td>{{pricePerKZR}} {{currency}} {{#if needsUSD options.acceptedCurrency}}{{#if USDprice options.acceptedCurrency pricePerKZR}}({{USDprice options.acceptedCurrency pricePerKZR}} USD){{/if}}{{/if}}</td>


### PR DESCRIPTION
Solution: Use momentjs to replace the absolute time with descriptive time (e.g. 'ends in 3 hours'). Use 'ends' for opened auctions and 'ended' for closed.