### PR TITLE
Problem: Invalid hashpower calculations for Ethereum Classic (#1215)

### DIFF
--- a/imports/api/hashing/methods.js
+++ b/imports/api/hashing/methods.js
@@ -329,7 +329,7 @@ Meteor.methods({
 		let mul = parseUnit(unit)
 
 		let cur = Currencies.findOne({
-			currencyName: new RegExp(currencyName, 'ig')
+			currencyName: new RegExp(`${currencyName.trim()}$`, 'ig')
 		})
 
 		if (cur) {


### PR DESCRIPTION
Solution: Fix the regex used to find the currency in `hashrateApi` method in order to prevent incorrect matches. (Ethereum Classic was sometimes matched instead of Ethereum)