### PR TITLE
Problem: Can't easily ban duplicate accounts (#1216)

### DIFF
--- a/imports/api/activityLog/activityIPs.js
+++ b/imports/api/activityLog/activityIPs.js
@@ -1,0 +1,24 @@
+import { Mongo } from 'meteor/mongo'
+import { developmentValidationEnabledFalse } from '../indexDB'
+import SimpleSchema from 'simpl-schema'
+
+export const ActivityIPs = new Mongo.Collection('activityips');
+
+var { Integer, RegEx } = SimpleSchema
+var { Id, Domain } = RegEx
+
+/*ActivityIPs.schema = new SimpleSchema({
+  _id: { type: Id },
+  time: { type: Integer },
+  owner: { type: Id },
+  type: { type: String },
+  from: { type: String },
+  content: { type: String },
+  read: { type: Boolean },
+}, { requiredByDefault: developmentValidationEnabledFalse });
+*/
+ActivityIPs.deny({
+  insert: () => true,
+  update: () => true,
+  remove: () => true
+})

--- a/imports/api/activityLog/methods.js
+++ b/imports/api/activityLog/methods.js
@@ -1,5 +1,5 @@
 import { Meteor } from 'meteor/meteor'
-import { ActivityLog } from '/imports/api/indexDB.js'
+import { ActivityLog, ActivityIPs, UserData } from '/imports/api/indexDB.js'
 import { log } from '/imports/api/utilities'
 
 export const sendMessage = function(userId, message, from) {
@@ -47,4 +47,130 @@ Meteor.methods({
 
     }
 
-});
+})
+
+Meteor.methods({
+  activityIPVote: function(ip, type) {
+    if (!Meteor.userId()) {
+      throw new Meteor.Error('Error.', 'Please log in first')
+    }
+
+    let mod = UserData.findOne({
+      _id: this.userId
+    }, {
+      fields: {
+        moderator: true
+      }
+    })
+
+    if (!mod || !mod.moderator) {
+      throw new Meteor.Error('Error.', 'mod-only')
+    }
+        
+    let activityIP = ActivityIPs.findOne({
+      ip: ip
+    })
+
+    const Future = require('fibers/future')
+    let fut = new Future()
+
+    if (!activityIP) { // if it still doesn't exist, create it
+      ActivityIPs.insert({
+        ip: ip,
+        votes: [],
+        score: 0,
+        upvotes: 0,
+        downvotes: 0
+      }, (err, data) => {
+        if (!err) {
+          fut.return(ActivityIPs.findOne({
+            _id: data
+          }))
+        } else {
+          throw new Meteor.Error('Error', 'An error has ocurred.')
+        }
+      })
+    } else {
+      fut.return(activityIP)
+    }
+
+    activityIP = fut.wait()
+
+    if (activityIP.ignored && activityIP.time > (new Date() - 1000*60*60*24*30)) {
+      throw new Meteor.Error('Error', 'This IP is still on the ignore list.')
+    }
+
+    if (!(activityIP.votes || []).filter(i => i.userId === this.userId).length) { // user hasn't voted yet
+      ActivityIPs.update({
+        _id: activityIP._id
+      }, {
+        $inc: {
+          score: type === 'voteUp' ? 1 : -1, // increase or decrease the current score
+          [type === 'voteUp' ? 'upvotes' : 'downvotes']: 1 // increase upvotes or downvotes
+        },
+        $push: {
+          votes: {
+            userId: this.userId,
+            type: type,
+            loggedIP: this.connection.clientAddress,
+            time: new Date().getTime()
+          }
+        }
+      })
+    }
+           
+    let approveChange = ActivityIPs.find({
+      _id: activityIP._id
+    }, {
+      fields: {
+        score: 1,
+        upvotes: 1,
+        downvotes: 1 
+      } 
+    }).fetch()[0]
+
+    // ignore the IP for a month if the score is >= 3
+    if (approveChange.score >= 3) {
+      ActivityIPs.update({
+        _id: activityIP._id
+      }, {
+        $set: {
+          score: 0, // reset all vote related values
+          upvotes: 0,
+          downvotes: 0,
+          votes: [],
+          ignored: true,
+          time: new Date().getTime()
+        }
+      })
+
+      return 'ok'
+    }
+
+    // Ban all users <= -3
+    if (approveChange.score <= -3) {
+      let users = UserData.find({}).fetch().filter(i => {
+        return i.sessionData && i.sessionData.some(j => j.loggedIP === ip) // IP was used by the user
+      })
+
+      users.forEach(i => {
+        Meteor.call('userStrike', i._id, 'duplicate', 's3rv3r-only', 4, (err, data) => {}) // all users earn 4 strikes here
+      })
+
+      ActivityIPs.update({
+        _id: activityIP._id
+      }, {
+        $set: {
+          score: 0, // reset all vote related values
+          upvotes: 0,
+          downvotes: 0,
+          votes: [],
+          ignored: false,
+          time: new Date().getTime()
+        }
+      })
+                
+      return 'not-ok'
+    }
+  }
+})

--- a/imports/api/activityLog/server/publications.js
+++ b/imports/api/activityLog/server/publications.js
@@ -1,5 +1,5 @@
 import { Meteor } from 'meteor/meteor'
-import { ActivityLog } from '/imports/api/indexDB.js'
+import { ActivityLog, ActivityIPs } from '/imports/api/indexDB.js'
 
 Meteor.publish('activitylog', function pending() {
   if(this.userId) {
@@ -8,3 +8,8 @@ Meteor.publish('activitylog', function pending() {
     return null;
   }
 })
+
+Meteor.publish('activityIPs', () => ActivityIPs.find({}))
+Meteor.publish('activityIP', (ip) => ActivityIPs.find({
+	ip: ip
+}))

--- a/imports/api/indexDB.js
+++ b/imports/api/indexDB.js
@@ -41,6 +41,7 @@ import { ChangedCurrencies } from '/imports/api/coins/changedCurrencies.js'
 import { Redflags } from '/imports/api/redflags/redflags.js'
 
 import { ActivityLog } from '/imports/api/activityLog/activityLog.js'
+import { ActivityIPs } from '/imports/api/activityLog/activityIPs'
 
 import { Bids } from '/imports/api/auctions/bids'
 import { Auctions } from '/imports/api/auctions/auctions'
@@ -100,6 +101,7 @@ export {
   Redflags,
 
   ActivityLog,
+  ActivityIPs,
 
   Bids,
   Auctions,

--- a/imports/api/users/methods.js
+++ b/imports/api/users/methods.js
@@ -113,13 +113,14 @@ Meteor.methods({
       }
     })
   },
-  userStrike: (userId, type, token) => {
+  userStrike: (userId, type, token, times) => {
+    times = times || 1
     if (token === 's3rv3r-only') {
       let user = UserData.findOne({
         _id: userId
       })
 
-      if (user && !user.moderator) {
+      if (user) {
         // add a strike to user's date
         UserData.update({
           _id: user._id
@@ -137,18 +138,18 @@ Meteor.methods({
           let val = i2.time > lastWeek ? 1 : 0
 
           return i1 + val
-        }, 0) + 1 : 0
+        }, 0) + times : times
 
         let lastMonth = new Date().getTime() - 24*60*60*1000*30 // one month (30 days average)
         let strikesMonth = user.strikes ? user.strikes.reduce((i1, i2) => {
           let val = i2.time > lastMonth ? 1 : 0
 
           return i1 + val
-        }, 0) + 1 : 0
+        }, 0) + times : times
 
         if (strikesWeek > 3 || strikesMonth > 6) {
           Meteor.users.update({
-            _id: Meteor.userId()
+            _id: userId
           }, {
             $set: {
               suspended: true

--- a/imports/api/users/server/publications.js
+++ b/imports/api/users/server/publications.js
@@ -150,7 +150,8 @@ import { UserData, ProfileImages, UsersStats } from '/imports/api/indexDB.js'
         email: 1,
         bio: 1,
         slug: 1,
-        profilePicture: 1
+        profilePicture: 1,
+        suspended: 1
       } // only show the absolutely required fields
     })
   })

--- a/imports/api/wallet/server/publications.js
+++ b/imports/api/wallet/server/publications.js
@@ -1,5 +1,5 @@
 import { Meteor } from 'meteor/meteor'
-import { WalletImages, Wallet } from '/imports/api/indexDB.js'
+import { WalletImages, Wallet, UserData } from '/imports/api/indexDB.js'
 
 Meteor.publish('walletimages', function walletimagesPublication(id) {
   if(id){
@@ -18,5 +18,38 @@ Meteor.publish('wallet', function wallet() {
     return Wallet.find({owner: this.userId});
   } else {
     return null;
+  }
+})
+
+Meteor.publish('walletsMod', () => {
+  let user = UserData.findOne({
+    _id: Meteor.userId()
+  })
+
+  if (Meteor.userId() && user && user.moderator) { // just in case the user is a moderator
+    return Wallet.find({
+      $and: [{
+        $or: [{
+          from: 'Blockrazor'
+        }, {
+          from: 'System'
+        }],
+        $or: [{
+          currency: 'KZR'
+        }, {
+          currency: {
+            $exists: false
+          }
+        }],
+        type: 'transaction'
+      }]
+    }, {
+      fields: {
+        owner: 1,
+        amount: 1
+      } // show only necessary fields
+    })
+  } else {
+    return null
   }
 })

--- a/imports/startup/both/routes.js
+++ b/imports/startup/both/routes.js
@@ -54,6 +54,7 @@ if (Meteor.isClient) { // only import them if this code is being executed on cli
   import '../../ui/pages/moderator/moderatorDash/moderatorDash'
   import '../../ui/pages/moderator/questions/questions'
   import '../../ui/pages/moderator/flaggedUsers/flaggedUsers'
+  import '../../ui/pages/moderator/flaggedUsers/flaggedIP'
   import '../../ui/pages/moderator/hashpower/flaggedHashpower'
   import '../../ui/pages/moderator/appLogs/appLogs'
   import '../../ui/pages/moderator/problems/solvedProblems'
@@ -631,12 +632,37 @@ adminRoutes.route('/flagged-users', {
   name: 'flaggedUsers',
   subscriptions: function () {
     this.register('userData', FastRenderer.subscribe('userData'));
-    this.register('users', FastRenderer.subscribe('users'));
+    this.register('users', FastRenderer.subscribe('users'))
+    this.register('activityIPs', FastRenderer.subscribe('activityIPs'))
   },
   action: function () {
     if (Meteor.userId()) {
       BlazeLayout.render('mainLayout', {
         main: 'flaggedUsers',
+        //left: 'sideNav'
+      })
+    } else {
+      window.last = window.location.pathname
+      FlowRouter.go('/login')
+    }
+  }
+})
+
+adminRoutes.route('/flagged-ip/:ip', {
+  name: 'flaggedIP',
+  subscriptions: function (params) {
+    this.register('userData', FastRenderer.subscribe('userData'))
+    this.register('users', FastRenderer.subscribe('users'))
+    this.register('activityIP', FastRenderer.subscribe('activityIP', params.ip))
+    this.register('features', FastRenderer.subscribe('features'))
+    this.register('redflags', FastRenderer.subscribe('redflags'))
+    this.register('approvedcurrencies', FastRenderer.subscribe('approvedcurrencies'))
+    this.register('walletsMod', FastRenderer.subscribe('walletsMod'))
+  },
+  action: function () {
+    if (Meteor.userId()) {
+      BlazeLayout.render('mainLayout', {
+        main: 'flaggedIP',
         //left: 'sideNav'
       })
     } else {

--- a/imports/ui/components/sideNav/sideNav.html
+++ b/imports/ui/components/sideNav/sideNav.html
@@ -41,7 +41,7 @@
                 <ul class="sub-menu collapse" id="service">
                     <li><a class="sub-item" href="/moderator/">Approvals</a></li>
                     <li><a class="sub-item" href="/changedCurrencies/">Proposed Changes</a></li>
-                    <li><a class="sub-item" href="/moderator/flagged-users">Flagged Users</a></li>
+                    <li><a class="sub-item" href="/moderator/flagged-users">Flagged IP addresses</a></li>
                     <li><a class="sub-item" href="/moderator/flagged-hashpower">Flagged Hashpower</a></li>
                     <li><a class="sub-item" href="/moderator/questions">Manage Rating Questions</a></li>
                     <li><a class="sub-item" href="/moderator/applogs">Application logs</a></li>

--- a/imports/ui/components/topNav/topNav.html
+++ b/imports/ui/components/topNav/topNav.html
@@ -49,7 +49,7 @@
                         </a>
                       </li>
                       <li class="nav-item">
-                        <a href="wallet" class="nav-link  text-muted ml-2 d-none d-sm-block">{{balance}} KZR
+                        <a href="/wallet" class="nav-link  text-muted ml-2 d-none d-sm-block">{{balance}} KZR
                         {{#if walletNotifications}}<span class="badge badge-pill badge-light">{{walletNotifications}}</span>{{/if}}
                         </a>
                       </li>

--- a/imports/ui/pages/moderator/flaggedUsers/flaggedIP.html
+++ b/imports/ui/pages/moderator/flaggedUsers/flaggedIP.html
@@ -1,0 +1,54 @@
+<template name="flaggedIP">
+    <h3>Flagged IP address: {{ip}}</h3>
+    <i>(data features five most recent items)</i><br />
+    {{#if isModerator}}
+    <table class="table">
+        <thead>
+            <tr>
+                <th scope="col">User</th>
+                <th scope="col">Moderator</th>
+                <th scope="col">Comments</th>
+                <th scope="col">Features</th>
+                <th scope="col">Red flags</th>
+                <th scope="col">Added currencies</th>
+                <th scope="col">Total earnings</th>
+                <th scope="col">Last access</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{#if subsCacheReady}}
+                {{#each users}}
+                    <tr>
+                        <td>{{username}}</td>
+                        <td>{{#if info.moderator}}Yes{{else}}No{{/if}}</td>
+                        <td>{{#each comments}}{{comment}} on <a href="/currency/{{currencyComment.slug}}">{{currencyComment.currencyName}}</a><br />{{else}}-{{/each}}</td>
+                        <td>{{#each features}}{{featureName}} on <a href="/currency/{{currency.slug}}">{{currency.currencyName}}</a><br />{{else}}-{{/each}}</td>
+                        <td>{{#each redflags}}{{name}} on <a href="/currency/{{currency.slug}}">{{currency.currencyName}}</a><br />{{else}}-{{/each}}</td>
+                        <td>{{#each currencies}}<a href="/currency/{{slug}}">{{currencyName}}</a><br />{{else}}-{{/each}}</td>
+                        <td>{{totalEarnings}} KZR</td>
+                        <td>{{lastAccess}}</td>
+                    </tr>
+                {{else}}
+                    {{> empty}}
+                {{/each}}
+            {{else}}
+                {{> loading}}
+            {{/if}}
+        </tbody>
+    </table>
+    
+    {{#if users.length}}
+    {{#with votes}}
+    <h4>Upvotes (ignore): {{upvotes}}</h4>
+    <h4>Downvotes (ban): {{downvotes}}</h4>
+
+    {{#unless voted}}
+    <button class="btn btn-default js-vote" data-vote="voteUp"><i class="fa fa-arrow-up"></i> These accounts are probably not the same person (ignore for a month)</button>
+    <button class="btn btn-default js-vote" data-vote="voteDown"><i class="fa fa-arrow-down"></i> These accounts are the same person (ban them all)</button>
+    {{/unless}}
+    {{/with}}
+    {{/if}}
+    {{else}}
+    <h5>You have to be a moderator to view this page.</h5>
+    {{/if}}
+</template>

--- a/imports/ui/pages/moderator/flaggedUsers/flaggedIP.js
+++ b/imports/ui/pages/moderator/flaggedUsers/flaggedIP.js
@@ -1,0 +1,162 @@
+import { Template } from 'meteor/templating'
+import { UserData, Features, Redflags, Currencies, Wallet, ActivityIPs } from '/imports/api/indexDB.js'
+import { FlowRouter } from 'meteor/staringatlights:flow-router';
+
+import './flaggedIP.html'
+
+Template.flaggedIP.onCreated(function() {
+	this.autorun(() => {
+		SubsCache.subscribe('userData')
+		SubsCache.subscribe('users')
+		SubsCache.subscribe('activityIP', FlowRouter.getParam('ip'))
+		SubsCache.subscribe('features')
+		SubsCache.subscribe('redflags')
+		SubsCache.subscribe('approvedcurrencies')
+		SubsCache.subscribe('walletsMod')
+	})
+})
+
+Template.flaggedIP.helpers({
+	currency: function() {
+		return Currencies.findOne({
+			_id: this.currencyId
+		})
+	},
+	currencyComment: function() {
+		return Currencies.findOne({
+			_id: (Features.findOne({
+				_id: this.parentId
+			}) || {}).currencyId || 
+			(Redflags.findOne({
+				_id: this.parentId
+			}) || {}).currencyId
+		})
+	},
+	currencies: function() {
+		return Currencies.find({
+			owner: this.user._id
+		}, {
+			sort: {
+				createdAt: -1
+			},
+			limit: 5
+		})
+	},
+	features: function() {
+		return Features.find({
+			createdBy: this.user._id,
+			featureName: {
+				$exists: true
+			}
+		}, {
+			sort: {
+				createdAt: -1
+			},
+			limit: 5
+		})
+	},
+	redflags: function() {
+		return Redflags.find({
+			createdBy: this.user._id,
+			name: {
+				$exists: true
+			}
+		}, {
+			sort: {
+				createdAt: -1
+			},
+			limit: 5
+		})
+	},
+	comments: function() {
+		return _.union(Features.find({
+			createdBy: this.user._id,
+			comment: {
+				$exists: true
+			}
+		}, {
+			sort: {
+				createdAt: -1
+			},
+			limit: 5
+		}).fetch(), Redflags.find({
+			createdBy: this.user._id,
+			comment: {
+				$exists: true
+			}
+		}, {
+			sort: {
+				createdAt: -1
+			},
+			limit: 5
+		}).fetch()).sort((i1, i2) => i2.createdAt - i1.createdAt).slice(0, 5)
+	},
+	totalEarnings: function() {
+		return Wallet.find({
+			owner: this.user._id
+		}).fetch().reduce((i1, i2) => i1 + Number(i2.amount), 0).toFixed(2)
+	},
+	ip: () => FlowRouter.getParam('ip'),
+	users: function() {
+		return Meteor.users.find({
+			$or: [{
+				suspended: false
+			}, {
+				suspended: {
+					$exists: false
+				}
+			}] // don't include banned users
+		}).fetch().map(i => {
+			return {
+				user: i,
+				info: (UserData.findOne({
+					_id: i._id
+				}) || {})
+			}
+		}).filter(i => {
+			return i.info.sessionData && i.info.sessionData.some(j => j.loggedIP === FlowRouter.getParam('ip')) // IP was used by the user
+		}).sort((i1, i2) => {
+			return i2.info.sessionData[i2.info.sessionData.length - 1].time - i1.info.sessionData[i1.info.sessionData.length - 1].time
+		})
+	},
+	username: function() {
+		return this.user.username === this.user.email ? this.user.username : `${this.user.username} ${this.user.email ? `(${this.user.email})` : ''}`
+	},
+	lastAccess: function() {
+		return moment(this.info.sessionData[this.info.sessionData.length - 1].time).fromNow()
+	},
+	voted: function() {
+		return !!(this.votes || []).filter(i => i.userId === Meteor.userId()).length
+	},
+	upvotes: function() {
+		return this.upvotes || 0
+	},
+	downvotes: function() {
+		return this.downvotes || 0
+	},
+	votes: () => ActivityIPs.findOne({
+		ip: FlowRouter.getParam('ip')
+	}) || {}
+})
+
+Template.flaggedIP.events({
+	'click .js-vote': function(event, templateInstance) {
+        let type = $(event.currentTarget).data('vote')
+
+        Meteor.call('activityIPVote', FlowRouter.getParam('ip'), type, (err, data) => {
+            if (err && err.error === 'mod-only') {
+                sAlert.error('Only moderators can vote')
+            }
+
+            if (data === 'ok') {
+                sAlert.success('IP successfully ignored.')
+
+                FlowRouter.go('/moderator/flagged-users')
+            } else if (data === 'not-ok') {
+            	sAlert.success('All users suspended.')
+
+            	FlowRouter.go('/moderator/flagged-users')
+            }
+        })
+    }
+})

--- a/imports/ui/pages/moderator/flaggedUsers/flaggedUsers.html
+++ b/imports/ui/pages/moderator/flaggedUsers/flaggedUsers.html
@@ -1,25 +1,21 @@
 <template name="flaggedUsers">
-    <h3>Flagged users</h3>
+    <h3>Flagged IP addresses</h3>
     {{#if isModerator}}
     <table class="table">
         <thead>
             <tr>
-                <th scope="col">Username</th>
-                <th scope="col">Email</th>
-                <th scope="col">IP address</th>
+                <th scope="col">Flagged IP</th>
+                <th scope="col">Users count</th>
                 <th scope="col">Last access</th>
-                <th scope="col">Active flags</th>
             </tr>
         </thead>
         <tbody>
             {{#if subsCacheReady}}
-                {{#each users}}
+                {{#each ipAddresses}}
                     <tr>
-                        <td>{{user.username}}</td>
-                        <td>{{user.email}}</td>
-                        <td>{{ipAddress}}</td>
+                        <td><a href="/moderator/flagged-ip/{{ip}}">{{ip}}</a></td>
+                        <td>{{users}}</td>
                         <td>{{lastAccess}}</td>
-                        <td>{{activeFlags}}</td>
                     </tr>
                 {{else}}
                     {{> empty}}

--- a/imports/ui/pages/suspended/suspended.js
+++ b/imports/ui/pages/suspended/suspended.js
@@ -11,7 +11,8 @@ const getName = (type) => {
 		'bad-wallet': 'Your wallet image was invalid',
 		'comment': 'Your comment has been flagged and deleted',
 		'redflags': 'Your redflag has been flagged and deleted',
-		'features': 'Your feature has been flagged and deleted'
+		'features': 'Your feature has been flagged and deleted',
+		'duplicate': 'You\'ve created multiple accounts which is not allowed.'
 	}
 
 	return o[type]
@@ -45,7 +46,7 @@ Template.suspended.helpers({
 			_id: Meteor.userId()
 		})
 
-		return user && user.strikes && user.strikes.map(i => ({
+		return user && user.strikes && user.strikes.sort((i1, i2) => i2.time - i1.time).map(i => ({
 			date: moment(i.time).fromNow(),
 			name: getName(i.type)
 		}))


### PR DESCRIPTION
Solution: Implement a new view where moderators can see all users that share an IP address (whether on signup, login or general access) and let moderators decide to either ban all duplicate accounts or to ignore the specific IP address for a month.