### PR TITLE
Problem: Distribution graph is deformed on small screens (#1302)

### DIFF
--- a/imports/ui/pages/currencyDetail/fundamentalMetrics.js
+++ b/imports/ui/pages/currencyDetail/fundamentalMetrics.js
@@ -104,7 +104,8 @@ Template.fundamentalMetrics.onRendered(function (){
       options: {
         tooltips: {enabled: false},
         responsive: false,
-        maintainAspectRatio: false,
+        maintainAspectRatio: true,
+        aspectRatio: 1,
         title: {display: false},
         legend: {
           display: true,


### PR DESCRIPTION
Solution: Add `chart.js` options that should force the correct aspect ratio and prevent deformations.