### PR TITLE
Problem: Suspended users cannot view and post problems/questions (#1333)

### DIFF
--- a/imports/api/problems/methods.js
+++ b/imports/api/problems/methods.js
@@ -8,7 +8,7 @@ import { sendMessage } from '/imports/api/activityLog/methods'
 export const newProblem = new ValidatedMethod({
   name: 'newProblem',
 	validate: //null,
-  new SimpleSchema(Problems.schema.pick("type","header","text","images","images.$","bounty","createdBy")
+  new SimpleSchema(Problems.schema.pick("type","header","text","images","images.$","bounty")
 	, {requiredByDefault: developmentValidationEnabledFalse }).validator(),
   run({ type, header, text, images, bounty }) {
 			if (Meteor.userId()) {

--- a/imports/startup/both/routes.js
+++ b/imports/startup/both/routes.js
@@ -80,7 +80,9 @@ FlowRouter.triggers.enter([ () => { window.scrollTo(0, 0); }, () => {
     })
 
     if (user && user.suspended) {
-      FlowRouter.go('/suspended') // redirect all suspended users here
+      if (!~['problems', 'problem', 'new-problem'].indexOf(FlowRouter.getRouteName())) { // let suspended users access problems page
+        FlowRouter.go('/suspended') // redirect all suspended users here
+      }
     }
   })
 } ])

--- a/imports/ui/components/sideNav/sideNav.html
+++ b/imports/ui/components/sideNav/sideNav.html
@@ -13,6 +13,7 @@
                 <a href="/login" class="btn btn-success sign-in-button">Sign In</a> {{/if}}
             </div>
             <ul id="menu-content" class="menu-content collapse out">
+                {{#unless currentUser.suspended}}
 				<li class="{{activeClass 'home'}}">
                     <a href="/">Home</a>
                 </li>
@@ -56,6 +57,11 @@
                     <li><a class="sub-item {{activeClass 'transactions'}}" href="/transactions/1">All Blockrazor Transactions</a></li>
                 </ul>
                 {{/if}}
+                {{else}}
+                <h3 style="text-align: center">Suspended</h3>
+                <li class="{{activeClass 'home'}}"><a href="/">Home</a></li>
+                <li class="{{activeClass 'problems'}}"><a href="/problems">Problems</a></li>
+                {{/unless}}
             </ul>
         </div>
     </div>

--- a/imports/ui/pages/suspended/suspended.html
+++ b/imports/ui/pages/suspended/suspended.html
@@ -23,5 +23,7 @@
             Your application is currently being processed by moderators. Good luck!
             {{/if}}
         {{/unless}}
+        <br /><br />
+        You can still access our <a href="/problems">problems and questions page</a>, if you want to report something.
     </div>
 </template>


### PR DESCRIPTION
Solution: Let suspended users access questions/problems, put a link to questions/problems on the suspended page, and hide other side bar links when the user is suspended.