### PR TITLE
Problem: Cannot specify instances for syncedcron jobs to run on (#1334)

### DIFF
--- a/imports/api/payments/server/startup.js
+++ b/imports/api/payments/server/startup.js
@@ -1,7 +1,9 @@
 Meteor.startup(() => {
+    //if (~['wallets'].indexOf(process.env.NODE_TYPE)) { // Execute the job iff NODE_TYPE environmental variable is set to 'wallets'. Adding more values to the array provides a granular control over which cronjobs should run where. If the cronjob runs on every instance, this if is not necessary. 
     SyncedCron.add({
         name: 'Get new Monero deposits',
         schedule: (parser) => parser.text('every 1 minutes'),
         job: () => Meteor.call('getNewPaymentsMonero', (err, data) => {})
     })
+    //}
 })


### PR DESCRIPTION
Solution: Use the value of environmental variable `NODE_TYPE` to determine whether to run a certain syncedcron job. An example how to use this is commented in `/imports/payments/server/startup.js`.