### PR TITLE
Problem: Hashpower API bounties are created for PoS currencies (#1323)

### DIFF
--- a/imports/api/coins/server/publications.js
+++ b/imports/api/coins/server/publications.js
@@ -59,7 +59,8 @@ Meteor.publish('bountyCurrencies', function(limit, skip) {
   let sub = Currencies.find({
     hashpowerApi: {
       $ne: true
-    } // skip all currencies that don't need to show on the bounty page
+    },
+    consensusSecurity: 'Proof of Work' // skip all currencies that don't need to show on the bounty page
   }, {
     limit: limit,
     skip: skip,

--- a/imports/ui/pages/bounties/bounties.js
+++ b/imports/ui/pages/bounties/bounties.js
@@ -158,7 +158,8 @@ Template.bounties.onCreated(function(){
     let currencies = Currencies.find({
       hashpowerApi: {
         $ne: true
-      }
+      },
+      consensusSecurity: 'Proof of Work'
     }).fetch().map(i => {
       let b = Bounties.findOne({
         type: `currency-${i.slug}`


### PR DESCRIPTION
Solution: Use only currencies that user `Proof of Work` as consensus security when generating hashpower API bounties.