### PR TITLE
Problem: Users cannot deposit Monero into their wallet (#1313)

### DIFF
--- a/imports/api/payments/server/methods.js
+++ b/imports/api/payments/server/methods.js
@@ -93,31 +93,47 @@ Meteor.methods({
 							blockHeight: newHeight
 						}
 					})
+					let payments = {}
+
 					data.result.payments.forEach(i => {
 						if (i.address === _XMRAddress) { // check if the address is correct, just in case, change to real address when in production
-							let user = ids.filter(j => j.paymentId === i.payment_id)
-
-							if (user.length) {
-								let payment = Payments.findOne({
-									userId: user[0].userId,
-									txHash: i.tx_hash
-								})
-
-								if (!payment) { // if the payment hasn't been processed yet
-									Payments.insert({
-										userId: user[0].userId,
-										paymentId: i.payment_id,
-										txHash: i.tx_hash,
-										date: new Date().getTime(),
-										amount: i.amount,
-										currency: 'XMR',
-										address: i.address
-									}) // save all possible data
-
-									let realAmount = i.amount / 1000000000000
-
-									transfer(user[0].userId, 'System', `You have deposited ${realAmount} XMR`, realAmount, 'XMR')
+							if (payments[i.tx_hash] && !_.isEmpty(payments[i.tx_hash])) {
+								payments[i.tx_hash].amount += i.amount // increase the amount if it's the same tx hash
+							} else {
+								payments[i.tx_hash] = {
+									paymentId: i.payment_id,
+									amount: i.amount,
+									address: i.address
 								}
+							}
+						}
+					})
+					console.log(payments)
+					Object.keys(payments).forEach(i => {
+						let tx = payments[i]
+
+						let user = ids.filter(j => j.paymentId === tx.paymentId)
+
+						if (user.length) {
+							let payment = Payments.findOne({
+								userId: user[0].userId,
+								txHash: i
+							})
+
+							if (!payment) {
+								Payments.insert({
+									userId: user[0].userId,
+									paymentId: tx.paymentId,
+									txHash: i,
+									date: new Date().getTime(),
+									amount: tx.amount,
+									currency: 'XMR',
+									address: tx.address
+								}) // save all possible data
+
+								let realAmount = tx.amount / 1000000000000
+
+								transfer(user[0].userId, 'System', `You have deposited ${realAmount} XMR`, realAmount, 'XMR')
 							}
 						}
 					})


### PR DESCRIPTION
Solution: Allow multiple transaction hashes in the same `bulkPayments` call and calculate the total amount by grouping all transactions with the same hash.