### PR TITLE
#1322 Fixed issue of currency image not showing up in moderator currency approval page

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,4 +11,5 @@ XiChen Tang (pilot.alternative@yandex.com)
 Heng Sok (jmspsi126@gmail.com)
 Aaron Miller (aarmillr09@gmail.com)
 David Juan Ahullana (d.juan@ahullana.com)
+Jigar Tank (jigartank@hupp.in)
 ----Please add your name above this line with your first pull request----

--- a/imports/ui/pages/moderator/moderatorDash/moderatorPendingCurrency.html
+++ b/imports/ui/pages/moderator/moderatorDash/moderatorPendingCurrency.html
@@ -21,7 +21,7 @@
                         <div class="row">
                             <div class="col-sm-12">
                                 <div class="card card-header d-flex align-items-center flex-row">
-                                    <img class="currency-logo" src="{{doesCoinImageExist currencyReview.currencyName.currencyLogoFilename}}" alt="{{currencyReview.currencyName}}">
+                                    <img class="currency-logo" src="{{doesCoinImageExist currencyReview.currencyLogoFilename}}" alt="{{currencyReview.currencyName}}">
                                     <input type="hidden" value="{{currencyLogoFilenam}}" id="currencyLogoFilename_existing">
                                     <div class="name">{{currencyReview.currencyName}}</div>
                                 </div>


### PR DESCRIPTION
Problem : When moderator goes to currency approval page he can't see image of newly added currency.

Solution : 
Replaced `currencyReview.currencyName.currencyLogoFilename` with `currencyReview.currencyLogoFilename`
Wrong file name reference was being called.