### PR TITLE
#1407 Problem: Flow.router deprecated warning in browser console log

### DIFF
--- a/imports/startup/both/routes.js
+++ b/imports/startup/both/routes.js
@@ -603,13 +603,13 @@ FlowRouter.route('/signup', {
 })
 
 // the App_notFound template is used for unknown routes and missing lists
-FlowRouter.notFound = {
+FlowRouter.route('*',{
   action: async (params, queryParams) => {
     BlazeLayout.render('error', {
       main: 'App_notFound'
     })
   }
-};
+});
 
 //moderator routes
 var adminRoutes = FlowRouter.group({


### PR DESCRIPTION
Solution : use FlowRouter.route('*', { /*...*/ }) instead!