### PR TITLE
Problem: Sweetaleart is not dynamically imported. (#1354)

### DIFF
--- a/imports/ui/components/topNav/topNav.js
+++ b/imports/ui/components/topNav/topNav.js
@@ -1,7 +1,7 @@
 import './topNav.html'
 import './topNav.scss'
 import '../global/globalHelpers'
-import swal from 'sweetalert';
+import('sweetalert').then(swal => window.swal = swal.default)
 
 import { colStub } from '/imports/ui/components/compatability/colStub'
 

--- a/imports/ui/layouts/mainLayout/mainLayout.js
+++ b/imports/ui/layouts/mainLayout/mainLayout.js
@@ -2,8 +2,8 @@ import { Template } from 'meteor/templating';
 import { developmentValidationEnabledFalse } from '/imports/startup/both/developmentValidationEnabledFalse'
 import './mainLayout.html'
 import './mainLayout.scss'
+import('sweetalert').then(swal => window.swal = swal.default)
 
-import swal from 'sweetalert';
 import Cookies from 'js-cookie';
 import validate from 'jquery-validation'
 

--- a/imports/ui/pages/addCoin/addCoin.js
+++ b/imports/ui/pages/addCoin/addCoin.js
@@ -3,8 +3,8 @@ import { developmentValidationEnabledFalse, FormData, Bounties, RatingsTemplates
 import { 
   addCoin
 } from '/imports/api/coins/methods' 
+import('sweetalert').then(swal => window.swal = swal.default)
 
-import swal from 'sweetalert';
 import Cookies from 'js-cookie';
 import smartWizard from 'smartwizard';
 

--- a/imports/ui/pages/codebase/codebase.js
+++ b/imports/ui/pages/codebase/codebase.js
@@ -1,7 +1,7 @@
 import { Template } from 'meteor/templating';
 import { Currencies, Ratings, Bounties } from '/imports/api/indexDB.js';
 import Cookies from 'js-cookie'
-import swal from 'sweetalert';
+import('sweetalert').then(swal => window.swal = swal.default)
 
 import './codebase.html'
 import './codebase.scss'

--- a/imports/ui/pages/communities/commQuestions.js
+++ b/imports/ui/pages/communities/commQuestions.js
@@ -1,7 +1,7 @@
 import { Template } from 'meteor/templating';
 import { Currencies, Ratings, Bounties } from '/imports/api/indexDB.js';
 import Cookies from 'js-cookie'
-import swal from 'sweetalert';
+import('sweetalert').then(swal => window.swal = swal.default)
 
 import './commQuestions.html'
 import './communities.scss'

--- a/imports/ui/pages/editProfile/editProfile.js
+++ b/imports/ui/pages/editProfile/editProfile.js
@@ -1,6 +1,6 @@
 import { Template } from 'meteor/templating';
 import { ProfileImages } from '/imports/api/indexDB.js'
-import swal from 'sweetalert';
+import('sweetalert').then(swal => window.swal = swal.default)
 
 import './editProfile.html'
 

--- a/imports/ui/pages/moderator/moderatorDash/approveCommunityImage.js
+++ b/imports/ui/pages/moderator/moderatorDash/approveCommunityImage.js
@@ -1,6 +1,6 @@
 import { Template } from 'meteor/templating';
 import './approveCommunityImage.html'
-import swal from 'sweetalert'
+import('sweetalert').then(swal => window.swal = swal.default)
 
 Template.approveCommunityImage.helpers({
         getThumbnailImage: function(img) {

--- a/imports/ui/pages/moderator/moderatorDash/moderatorPendingCurrency.js
+++ b/imports/ui/pages/moderator/moderatorDash/moderatorPendingCurrency.js
@@ -1,7 +1,6 @@
 import { Template } from 'meteor/templating'
 import './moderatorPendingCurrency.html'
-
-import swal from 'sweetalert'
+import('sweetalert').then(swal => window.swal = swal.default)
 
 Template.moderatorPendingCurrency.onCreated(function() {
 

--- a/imports/ui/pages/problems/problem.js
+++ b/imports/ui/pages/problems/problem.js
@@ -1,7 +1,7 @@
 import { Template } from 'meteor/templating'
 import { UserData, Problems } from '/imports/api/indexDB'
 import { FlowRouter } from 'meteor/ostrio:flow-router-extra'
-import swal from 'sweetalert'
+import('sweetalert').then(swal => window.swal = swal.default)
 
 import './problem.html'
 import './problemImages'

--- a/imports/ui/pages/ratings/question.js
+++ b/imports/ui/pages/ratings/question.js
@@ -1,6 +1,6 @@
 import { Template } from 'meteor/templating';
 import { Currencies, Ratings } from '/imports/api/indexDB.js';
-import swal from 'sweetalert';
+import('sweetalert').then(swal => window.swal = swal.default)
 
 import './question.html'
 import './ratings.scss'

--- a/imports/ui/pages/ratings/ratings.js
+++ b/imports/ui/pages/ratings/ratings.js
@@ -9,7 +9,7 @@ import './question'
 import './upload'
 
 import Cookies from 'js-cookie'
-import swal from 'sweetalert';
+import('sweetalert').then(swal => window.swal = swal.default)
 
 Template.ratings.onCreated(function bodyOnCreated() {
   var self = this


### PR DESCRIPTION
Solution: Import sweetalert dynamically only when it's needed in order to improve perfomance and reduce overall bundle size.