### PR TITLE
Problem: reactive-table, moment, sweetalert2 are not dynamically imported (#1438)

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -24,7 +24,6 @@ session@1.1.7
 raix:handlebar-helpers
 accounts-ui@1.2.0
 accounts-password@1.5.0
-cleandersonlobo:sweetalert2
 simple:reactive-method
 juliancwirko:s-alert
 barbatus:stars-rating
@@ -40,7 +39,6 @@ ostrio:loggermongo
 todda00:friendly-slugs
 cfs:graphicsmagick
 check
-momentjs:moment
 blaze-html-templates
 fourseven:scss
 gwendall:hovercard

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -29,7 +29,6 @@ callback-hook@1.0.10
 cfs:graphicsmagick@0.0.18
 check@1.2.5
 chuangbo:cookie@1.1.0
-cleandersonlobo:sweetalert2@1.4.0
 coffeescript@1.12.7_3
 coffeescript-compiler@1.12.7_3
 constellation:autopublish@0.4.4
@@ -93,7 +92,6 @@ mobile-experience@1.0.5
 mobile-status-bar@1.0.14
 modules@0.11.0
 modules-runtime@0.9.1
-momentjs:moment@2.20.1
 mongo@1.3.1
 mongo-dev-server@1.1.0
 mongo-id@1.0.6

--- a/client/main.js
+++ b/client/main.js
@@ -4,6 +4,17 @@ import {FlowRouter} from 'meteor/ostrio:flow-router-extra';
 window.FlowRouter = FlowRouter
 
 import { colStub } from '/imports/ui/components/compatability/colStub'
+import { moment } from '/imports/ui/components/compatability/moment'
+
+window.moment = moment // stub the moment package so we can dynamically import it without breaking anything
+
+import('moment').then(moment => {
+    let oldRef = window.moment 
+
+    window.moment = moment.default
+
+    oldRef().change() // notify all helpers and handlers that moment has been imported
+})
 
 UserData = Features = Summaries = Redflags = colStub // stub collections until they're loaded
 

--- a/imports/ui/components/compatability/moment.js
+++ b/imports/ui/components/compatability/moment.js
@@ -1,0 +1,22 @@
+const dep = new Tracker.Dependency
+
+const moment = () => ({
+    fromNow: () => {
+    	dep.depend()
+
+    	return ''
+	},
+    diff: () => {
+        dep.depend()
+
+        return 0
+    },
+    format: () => {
+        dep.depend()
+
+        return ''
+    },
+    change: () => dep.changed() // in order to retain reactivity, use this to notify helpers that they can now use moment to parse dates
+})
+
+export { moment }

--- a/imports/ui/components/topNav/topNav.js
+++ b/imports/ui/components/topNav/topNav.js
@@ -1,7 +1,7 @@
 import './topNav.html'
 import './topNav.scss'
 import '../global/globalHelpers'
-import('sweetalert').then(swal => window.swal = swal.default)
+import('sweetalert2').then(swal => window.swal = swal.default)
 
 import { colStub } from '/imports/ui/components/compatability/colStub'
 

--- a/imports/ui/layouts/mainLayout/mainLayout.js
+++ b/imports/ui/layouts/mainLayout/mainLayout.js
@@ -2,7 +2,7 @@ import { Template } from 'meteor/templating';
 import { developmentValidationEnabledFalse } from '/imports/startup/both/developmentValidationEnabledFalse'
 import './mainLayout.html'
 import './mainLayout.scss'
-import('sweetalert').then(swal => window.swal = swal.default)
+import('sweetalert2').then(swal => window.swal = swal.default)
 
 import Cookies from 'js-cookie';
 import validate from 'jquery-validation'
@@ -86,7 +86,7 @@ Template.mainLayout.events({
                   swal({
                       icon: "success",
                       text: 'Thanks for registering! We will drop you an email when we officially launch Block Razor',
-                      button: { className: 'btn btn-primary' }
+                      confirmButtonClass: 'btn btn-primary'
                   });
               }
           })

--- a/imports/ui/pages/addCoin/addCoin.js
+++ b/imports/ui/pages/addCoin/addCoin.js
@@ -3,7 +3,7 @@ import { developmentValidationEnabledFalse, FormData, Bounties, RatingsTemplates
 import { 
   addCoin
 } from '/imports/api/coins/methods' 
-import('sweetalert').then(swal => window.swal = swal.default)
+import('sweetalert2').then(swal => window.swal = swal.default)
 
 import Cookies from 'js-cookie';
 import smartWizard from 'smartwizard';

--- a/imports/ui/pages/bounties/bounties.js
+++ b/imports/ui/pages/bounties/bounties.js
@@ -1,6 +1,7 @@
 import { Template } from 'meteor/templating';
 import { Bounties, REWARDCOEFFICIENT, Problems, Currencies, PendingCurrencies, UserData, Ratings, HashPower } from '/imports/api/indexDB.js';
 import Cookies from 'js-cookie';
+import('sweetalert2').then(swal => window.swal = swal.default)
 
 export const LocalBounties = new Mongo.Collection(null)
 

--- a/imports/ui/pages/codebase/codebase.js
+++ b/imports/ui/pages/codebase/codebase.js
@@ -1,7 +1,7 @@
 import { Template } from 'meteor/templating';
 import { Currencies, Ratings, Bounties } from '/imports/api/indexDB.js';
 import Cookies from 'js-cookie'
-import('sweetalert').then(swal => window.swal = swal.default)
+import('sweetalert2').then(swal => window.swal = swal.default)
 
 import './codebase.html'
 import './codebase.scss'

--- a/imports/ui/pages/communities/commQuestions.js
+++ b/imports/ui/pages/communities/commQuestions.js
@@ -1,7 +1,7 @@
 import { Template } from 'meteor/templating';
 import { Currencies, Ratings, Bounties } from '/imports/api/indexDB.js';
 import Cookies from 'js-cookie'
-import('sweetalert').then(swal => window.swal = swal.default)
+import('sweetalert2').then(swal => window.swal = swal.default)
 
 import './commQuestions.html'
 import './communities.scss'

--- a/imports/ui/pages/communities/communities.js
+++ b/imports/ui/pages/communities/communities.js
@@ -1,6 +1,7 @@
 import { Template } from 'meteor/templating';
 import { Currencies, Ratings, Bounties } from '/imports/api/indexDB.js';
 import Cookies from 'js-cookie'
+import('sweetalert2').then(swal => window.swal = swal.default)
 
 import './communities.html'
 import './commCurrencyChoices'
@@ -62,14 +63,14 @@ Template.communities.events({
 				swal({
                     icon: "error",
                     text: err.reason,
-                    button: { className: 'btn btn-primary' }
+                    confirmButtonClass: 'btn btn-primary'
                 });
             } else {
 				swal({
 					icon: "warning",
 					title: "We detect lazy answering!",
 					text: _lazyAnsweringWarningText,
-					button: { text: 'continue', className: 'btn btn-primary' }
+					confirmButtonClass: 'btn btn-primary'
 				}).then((value) => {
 					if (!Ratings.findOne({
 	                    $or: [{
@@ -83,7 +84,7 @@ Template.communities.events({
 						swal({
 		                    icon: "error",
 		                    text: 'Please add some communities to continue.',
-		                    button: { className: 'btn btn-primary' }
+		                    confirmButtonClass: 'btn btn-primary'
 		                });
 	                }
 				});

--- a/imports/ui/pages/currencyDetail/currencyInfo.js
+++ b/imports/ui/pages/currencyDetail/currencyInfo.js
@@ -11,6 +11,7 @@ import {
 import './currencyInfo.html'
 import './currencyInfo.scss'
 import '/imports/ui/components/typeahead'
+import('sweetalert2').then(swal => window.swal = swal.default)
 
 Template.currencyInfo.onCreated(function () {
   this.autorun(() => {
@@ -199,9 +200,7 @@ Template.currencyInfo.events({
         swal({
           icon: "error",
           text: "Image must be under 2mb",
-          button: {
-            className: 'btn btn-primary'
-          }
+          confirmButtonClass: 'btn btn-primary'
         });
         uploadError = true;
       }
@@ -210,9 +209,7 @@ Template.currencyInfo.events({
         swal({
           icon: "error",
           text: "File must be an image",
-          button: {
-            className: 'btn btn-primary'
-          }
+          confirmButtonClass: 'btn btn-primary'
         });
         uploadError = true;
       }
@@ -235,9 +232,7 @@ Template.currencyInfo.events({
               swal({
                 icon: "error",
                 text: error.message,
-                button: {
-                  className: 'btn btn-primary'
-                }
+                confirmButtonClass: 'btn btn-primary'
               });
             } else {
 

--- a/imports/ui/pages/editProfile/editProfile.js
+++ b/imports/ui/pages/editProfile/editProfile.js
@@ -1,6 +1,6 @@
 import { Template } from 'meteor/templating';
 import { ProfileImages } from '/imports/api/indexDB.js'
-import('sweetalert').then(swal => window.swal = swal.default)
+import('sweetalert2').then(swal => window.swal = swal.default)
 
 import './editProfile.html'
 
@@ -29,7 +29,7 @@ Template.editProfile.events({
                 swal({
                     icon: "success",
                     text: 'Your profile has been updated',
-                    button: { className: 'btn btn-primary' }
+                    confirmButtonClass: 'btn btn-primary'
                   });
             }
         })

--- a/imports/ui/pages/moderator/moderatorDash/approveCommunityImage.js
+++ b/imports/ui/pages/moderator/moderatorDash/approveCommunityImage.js
@@ -1,6 +1,6 @@
 import { Template } from 'meteor/templating';
 import './approveCommunityImage.html'
-import('sweetalert').then(swal => window.swal = swal.default)
+import('sweetalert2').then(swal => window.swal = swal.default)
 
 Template.approveCommunityImage.helpers({
         getThumbnailImage: function(img) {
@@ -21,17 +21,14 @@ Template.approveCommunityImage.events({
       },
   'click #reject': function(event) {
 
-      swal("Why are you rejecting this?", {
+      swal({
+        text: "Why are you rejecting this?",
         type: "warning",
-              content: "input",
-              button: { className: 'btn btn-primary' },
-              showCancelButton: true,
-              attributes: {
-                  type: "text",
-                  required: true,
-              }
-          })
-          .then((rejectionReason) => {
+        input: "text",
+        confirmButtonClass: 'btn btn-primary',
+        cancelButtonClass: 'btn',
+        showCancelButton: true
+      }).then((rejectionReason) => {
 
               if (rejectionReason) {
                   Meteor.call('flagCommunityImage', this._id, rejectionReason, (err, data) => {

--- a/imports/ui/pages/moderator/moderatorDash/approveWalletImage.js
+++ b/imports/ui/pages/moderator/moderatorDash/approveWalletImage.js
@@ -1,5 +1,6 @@
 import { Template } from 'meteor/templating';
 import './approveWalletImage.html'
+import('sweetalert2').then(swal => window.swal = swal.default)
 
 Template.approveWalletImage.events({
 'click .image': function(event) {
@@ -13,14 +14,13 @@ Template.approveWalletImage.events({
 
     },
   'click #reject': function(event){
-          swal("Why are you rejecting this?", {
-              content: "input",
-              button: { className: 'btn btn-primary' },
-              showCancelButton: true,
-              attributes: {
-                  type: "text",
-                  required: true,
-              }
+          swal({
+              text: "Why are you rejecting this?",
+              type: "warning",
+              input: "text",
+              confirmButtonClass: 'btn btn-primary',
+              cancelButtonClass: 'btn',
+              showCancelButton: true
           })
           .then((rejectionReason) => {
 

--- a/imports/ui/pages/moderator/moderatorDash/moderatorPendingCurrency.js
+++ b/imports/ui/pages/moderator/moderatorDash/moderatorPendingCurrency.js
@@ -1,6 +1,6 @@
 import { Template } from 'meteor/templating'
 import './moderatorPendingCurrency.html'
-import('sweetalert').then(swal => window.swal = swal.default)
+import('sweetalert2').then(swal => window.swal = swal.default)
 
 Template.moderatorPendingCurrency.onCreated(function() {
 
@@ -46,7 +46,7 @@ Template.moderatorPendingCurrency.events({
                 swal({
                     icon: "error",
                     text: err.error,
-                    button: { className: 'btn btn-primary' }
+                    confirmButtonClass: 'btn btn-primary'
                 });
             }
             

--- a/imports/ui/pages/problems/problem.js
+++ b/imports/ui/pages/problems/problem.js
@@ -1,7 +1,7 @@
 import { Template } from 'meteor/templating'
 import { UserData, Problems } from '/imports/api/indexDB'
 import { FlowRouter } from 'meteor/ostrio:flow-router-extra'
-import('sweetalert').then(swal => window.swal = swal.default)
+import('sweetalert2').then(swal => window.swal = swal.default)
 
 import './problem.html'
 import './problemImages'

--- a/imports/ui/pages/ratings/currencyChoices.js
+++ b/imports/ui/pages/ratings/currencyChoices.js
@@ -1,5 +1,6 @@
 import { Template } from 'meteor/templating'
-import { Currencies, Ratings, WalletImages } from '/imports/api/indexDB.js';
+import { Currencies, Ratings, WalletImages } from '/imports/api/indexDB.js'
+import('sweetalert2').then(swal => window.swal = swal.default)
 
 import './currencyChoices.html'
 
@@ -97,20 +98,20 @@ Template.currencyChoices.events({
                 swal({
                     icon: "error",
                     text: "Please upload at least two wallet images to continue.",
-                    button: { className: 'btn btn-primary' }
+                    confirmButtonClass: 'btn btn-primary'
                 });
             } else if (walletCheckCount >= 3 && walletCheckCount < 6) {
                 swal({
                     icon: "error",
                     text: "Please upload one more wallet image to continue.",
-                    button: { className: 'btn btn-primary' }
+                    confirmButtonClass: 'btn btn-primary'
                 });
             } else {
 				swal({
                     icon: "warning",
 					title: "We detect lazy answering!",
                     text: _lazyAnsweringWarningText,
-                    button: { text: 'continue', className: 'btn btn-primary' }
+                    confirmButtonClass: 'btn btn-primary'
                 });
             }
 

--- a/imports/ui/pages/ratings/question.js
+++ b/imports/ui/pages/ratings/question.js
@@ -1,6 +1,6 @@
 import { Template } from 'meteor/templating';
 import { Currencies, Ratings } from '/imports/api/indexDB.js';
-import('sweetalert').then(swal => window.swal = swal.default)
+import('sweetalert2').then(swal => window.swal = swal.default)
 
 import './question.html'
 import './ratings.scss'
@@ -83,7 +83,7 @@ Template.question.events({
 					swal({
 						icon: "error",
 						text: _lazyAnsweringErrorText,
-						button: { className: 'btn btn-primary' }
+						confirmButtonClass: 'btn btn-primary'
 					});
 				}
 			}
@@ -93,7 +93,7 @@ Template.question.events({
 					swal({
 						icon: "warning",
 						text: 'Your answer is in contradiction with your previous answers. Please try again. If this persists, your progress will be purged and bounties will be nullified.',
-						button: { className: 'btn btn-primary' }
+						confirmButtonClass: 'btn btn-primary'
 					});
                 } else {
                     Meteor.call('deleteWalletRatings', (err, data) => {})
@@ -101,7 +101,7 @@ Template.question.events({
 					swal({
 						icon: "error",
 						text: _lazyAnsweringErrorText,
-						button: { className: 'btn btn-primary' }
+						confirmButtonClass: 'btn btn-primary'
 					});
                 }
             }
@@ -114,7 +114,7 @@ Template.question.events({
 				swal({
 					icon: "error",
 					text: _lazyAnsweringErrorText,
-					button: { className: 'btn btn-primary' }
+					confirmButtonClass: 'btn btn-primary'
 				});
             }
         })

--- a/imports/ui/pages/ratings/ratings.js
+++ b/imports/ui/pages/ratings/ratings.js
@@ -9,7 +9,7 @@ import './question'
 import './upload'
 
 import Cookies from 'js-cookie'
-import('sweetalert').then(swal => window.swal = swal.default)
+import('sweetalert2').then(swal => window.swal = swal.default)
 
 Template.ratings.onCreated(function bodyOnCreated() {
   var self = this

--- a/package-lock.json
+++ b/package-lock.json
@@ -5431,6 +5431,11 @@
         "promise-polyfill": "6.1.0"
       }
     },
+    "sweetalert2": {
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-7.19.3.tgz",
+      "integrity": "sha512-MSRDuAkBqlvAq6xeODNs+TvXE7ddgOuvF7JEGlWMllCHTteXUB+dviqZ0FNFaRUU55dIiS8o4F4O+TnnIVwIeA=="
+    },
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "scrollmagic": "^2.0.5",
     "simpl-schema": "^1.4.2",
     "smartwizard": "^4.3.1",
-    "sweetalert": "^2.1.0",
+    "sweetalert2": "^7.19.3",
     "underscore": "^1.8.3",
     "wdio-mocha-framework": "^0.5.13",
     "webdriverio": "^4.12.0",


### PR DESCRIPTION
Solution: Remove Meteor `momentjs:moment` package and replace it with dynamically imported `moment` npm package. Stub `moment` before the package is loaded in order to prevent inconsistent behavior. Remove `sweetalert2` Meteor package, and use dynamically imported `sweetalert2` npm package sitewide. Update existing `sweetalert` npm package to `sweetalert2`. Upgrade the existing `sweetalert` code to `sweetalert2` API.