### PR TITLE
Problem: Exchanges can be removed without moderation (#1448)

### DIFF
--- a/imports/api/exchanges/exchanges.js
+++ b/imports/api/exchanges/exchanges.js
@@ -33,6 +33,15 @@ Exchanges.schema = new SimpleSchema({
   "currencies.$._id": { type: Id},
   'currencies.$.name': { type: String },
   'currencies.$.slug': { type: String },
+  scores: { type: Integer },
+  upvotes: { type: Integer },
+  votes: { type: Array },
+  "votes.$": { type: Object }, 
+  "votes.$.userId": { type: Id }, 
+  "votes.$.type": { type: String }, 
+  "votes.$.loggedIP": { type: String }, 
+  "votes.$.time": { type: Integer },
+  removalProposed: { type: Boolean }
 }, { requiredByDefault: developmentValidationEnabledFalse });
 
 Exchanges.deny({

--- a/imports/api/exchanges/server/publications.js
+++ b/imports/api/exchanges/server/publications.js
@@ -4,3 +4,9 @@ import { Exchanges } from '/imports/api/indexDB.js'
 Meteor.publish('exchanges', function () {
   return Exchanges.find();
 })
+
+Meteor.publish('modExchanges', function () {
+  return Exchanges.find({
+  	removalProposed: true
+  })
+})

--- a/imports/startup/both/routes.js
+++ b/imports/startup/both/routes.js
@@ -698,6 +698,24 @@ adminRoutes.route('/candidates', {
   }
 })
 
+adminRoutes.route('/exchanges', {
+  name: 'exchanges-removal',
+  subscriptions: function () {
+    this.register('modExchanges', FastRenderer.subscribe('modExchanges'))
+  },
+  action: async (params, queryParams) => {
+    if (Meteor.userId()) {
+      await import ('/imports/ui/pages/moderator/exchanges/removeExchanges')
+      BlazeLayout.render('mainLayout', {
+        main: 'removeExchanges'
+      })
+    } else {
+      window.last = window.location.pathname
+      FlowRouter.go('/login')
+    }
+  }
+})
+
 adminRoutes.route('/flagged-ip/:ip', {
   name: 'flaggedIP',
   subscriptions: function (params) {

--- a/imports/ui/components/sideNav/sideNav.html
+++ b/imports/ui/components/sideNav/sideNav.html
@@ -49,6 +49,7 @@
                     <li><a class="sub-item {{activeClass 'changedCurrencies'}}" href="/changedCurrencies/"><i class="fas fa-edit"></i>Proposed Changes</a></li>
                     <li><a class="sub-item {{activeClass 'flaggedUsers'}}" href="/moderator/flagged-users"><i class="fas fa-map-marker"></i>Flagged IP addresses</a></li>
                     <li><a class="sub-item {{activeClass 'candidates'}}" href="/moderator/candidates"><i class="fas fa-user-secret"></i>Moderator candidates</a></li>
+                    <li><a class="sub-item {{activeClass 'exchanges-removal'}}" href="/moderator/exchanges"><i class="fas fa-user-secret"></i>Remove exchanges</a></li>
                     <li><a class="sub-item {{activeClass 'flagged-hashpower'}}" href="/moderator/flagged-hashpower"><i class="fas fa-flag"></i>Flagged Hashpower</a></li>
                     <li><a class="sub-item {{activeClass 'questions'}}" href="/moderator/questions"><i class="fas fa-star"></i>Manage Rating Questions</a></li>
                     <li><a class="sub-item {{activeClass 'app-logs'}}" href="/moderator/applogs"><i class="fas fa-file-alt"></i>Application logs</a></li>

--- a/imports/ui/pages/exchanges/exchanges.js
+++ b/imports/ui/pages/exchanges/exchanges.js
@@ -14,9 +14,9 @@ Template.exchangeActions.events({
   'click .deleteExchange': function (event, templ) {
     Meteor.call("deleteExchange", $(event.target).data("id"), (err, res) => {
       if (!err) {
-        sAlert.success("The exchange succesfully deleted.")
+        sAlert.success('Exchange removal successfully proposed. Moderators will decide whether to actually delete it or not.')
       } else {
-        sAlert.error("There is a problem with deleting the exchange")
+        sAlert.error('There is a problem with proposing exchange removal.')
       }
     })
   }

--- a/imports/ui/pages/moderator/exchanges/removeExchanges.html
+++ b/imports/ui/pages/moderator/exchanges/removeExchanges.html
@@ -1,0 +1,39 @@
+<template name="removeExchanges">
+    <h3>Exchanges proposed for removal</h3>
+    {{#if isModerator}}
+    <table class="table">
+        <thead>
+            <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Affected currencies</th>
+                <th scope="col">Voting score</th>
+                <th scope="col">Vote</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{#if subsCacheReady}}
+                {{#each exchanges}}
+                    <tr>
+                        <td><a href="/profile/{{user.slug}}">{{name}}</a></td>
+                        <td>{{currencies}}</td>
+                        <td>{{score}} ({{upvotes}}, {{downvotes}})</td>
+                        <td>{{#unless voted}}
+                            <button class="btn btn-default js-vote" data-vote="voteUp"><i class="fa fa-arrow-up"></i></button>
+                            <button class="btn btn-default js-vote" data-vote="voteDown"><i class="fa fa-arrow-down"></i></button>
+                            {{else}}
+                            -
+                            {{/unless}}
+                        </td>
+                    </tr>
+                {{else}}
+                    {{> empty}}
+                {{/each}}
+            {{else}}
+                {{> loading}}
+            {{/if}}
+        </tbody>
+    </table>
+    {{else}}
+    <h5>You have to be a moderator to view this page.</h5>
+    {{/if}}
+</template>

--- a/imports/ui/pages/moderator/exchanges/removeExchanges.js
+++ b/imports/ui/pages/moderator/exchanges/removeExchanges.js
@@ -1,0 +1,52 @@
+import { Template } from 'meteor/templating'
+import { UserData, Exchanges } from '/imports/api/indexDB.js'
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra'
+
+import './removeExchanges.html'
+
+Template.removeExchanges.onCreated(function() {
+	this.autorun(() => {
+		SubsCache.subscribe('modExchanges')
+	})
+})
+
+Template.removeExchanges.helpers({
+	exchanges: function() {
+		return Exchanges.find({
+			removalProposed: true
+		})
+	},
+	currencies: function() {
+		return this.currencies.map(i => i.name).toString().replace(/,/ig, ', ')
+	},
+	voted: function() {
+		return !!(this.votes || []).filter(i => i.userId === Meteor.userId()).length
+	},
+	upvotes: function() {
+		return this.upvotes || 0
+	},
+	downvotes: function() {
+		return this.downvotes || 0
+	},
+	score: function() {
+		return this.score || 0
+	}
+})
+
+Template.removeExchanges.events({
+	'click .js-vote': function(event, templateInstance) {
+        let type = $(event.currentTarget).data('vote')
+
+        Meteor.call('exchangeVote', this._id, type, (err, data) => {
+            if (err && err.error === 'mod-only') {
+                sAlert.error('Only moderators can vote')
+            }
+
+            if (data === 'ok') {
+                sAlert.success('Successfully removed.')
+            } else if (data === 'not-ok') {
+            	sAlert.success('Removal denied.')
+            }
+        })
+    }
+})


### PR DESCRIPTION
Solution: Change the behavior of the remove button on `/exchanges` page. Now, instead of deleting the exchange, it proposes the removal, and moderators have to either approve or deny the removal. Add a new page where moderators can do exactly that.