### PR TITLE
Problem: popper.js is in the bundle (20kb) (#1439)

### DIFF
--- a/imports/startup/client/index.js
+++ b/imports/startup/client/index.js
@@ -1,5 +1,5 @@
 import ('/imports/ui/components/compatability/index.js')
-import 'bootstrap'
+import ('bootstrap')
 import '/imports/api/users/client/users.js'
 import '/imports/api/miscellaneous/mime'
 import '../both/routes.js'

--- a/imports/ui/pages/theme.html
+++ b/imports/ui/pages/theme.html
@@ -1416,7 +1416,6 @@
 
 
       <script src="../_vendor/jquery/dist/jquery.min.js"></script>
-      <script src="../_vendor/popper.js/dist/umd/popper.min.js"></script>
       <script src="../_vendor/bootstrap/dist/js/bootstrap.min.js"></script>
       <script src="../_assets/js/custom.js"></script>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1950,11 +1950,6 @@
         "is-arrayish": "0.2.1"
       }
     },
-    "es6-object-assign": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -4670,11 +4665,6 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
-    "promise-polyfill": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.1.0.tgz",
-      "integrity": "sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc="
-    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -5421,15 +5411,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
-    },
-    "sweetalert": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sweetalert/-/sweetalert-2.1.0.tgz",
-      "integrity": "sha512-9YKj0SvjKyBfRWco50UOsIbXVeifYbxzT9Qda7EsqC01eafHGCSG0IR7g942ufjzt7lnwO8ZZBwr6emXv2fQrg==",
-      "requires": {
-        "es6-object-assign": "1.1.0",
-        "promise-polyfill": "6.1.0"
-      }
     },
     "sweetalert2": {
       "version": "7.19.3",


### PR DESCRIPTION
Solution: Dynamically import `bootstrap` to prevent eager importing of `popper.js`. Dynamically importing `bootstrap` also has performance benefits.