### PR TITLE
Problem: overlapping share button with header on /bounties #1466

### DIFF
--- a/imports/ui/pages/bounties/bounties.scss
+++ b/imports/ui/pages/bounties/bounties.scss
@@ -4,15 +4,15 @@
   padding: 15px 20px 0px 20px;
   //border: 0;
   //background: white;
-  
+
   .filter-label, .share-label {
-    display:inline-block; 
+    display:inline-block;
     width:100%;
     margin-bottom: 10px;
   }
   .form-check-item {
     display: inline-block;
-    
+
     .custom-checkbox {
       .form-check-input {
         margin-left: 0px;
@@ -34,7 +34,7 @@
 
 #js-shareUrl {
   padding: 3px 10px 3px 10px;
-  margin-top: -35px !important;
+  margin-top: -20px !important;
   margin-bottom: 15px;
   height: 27px;
 


### PR DESCRIPTION

Solution: Change the top margin for js-shareurl to -20px from -35px


![screen shot 2018-05-07 at 1 15 13 pm](https://user-images.githubusercontent.com/12807846/39690717-b597e638-51f8-11e8-98b7-dcb479f681ff.png)