### PR TITLE
Problem: [/wallet] kzr notifications not shown #1477

### DIFF
--- a/imports/api/wallet/methods.js
+++ b/imports/api/wallet/methods.js
@@ -224,7 +224,11 @@ Meteor.methods({
 		if (currency === 'kzr') {
 			filterOptions = {
 				owner: Meteor.userId,
-				currency: { $exists: false }
+				$or: [{
+          currency: { $exists: false }
+        },{
+          currency: currency.toUpperCase()
+        }]
 			}
 		} else {
 			filterOptions = {

--- a/imports/ui/pages/wallet/wallet.html
+++ b/imports/ui/pages/wallet/wallet.html
@@ -23,8 +23,8 @@
             <img class="card-logo" src="{{currencyLogo 'krazor'}}">
             <h4>
 				<b>Krazor</b>
-				{{#if currencyNotifications currency}}
-					<span class="badge badge-success">{{currencyNotifications currency}}</span>
+				{{#if currencyNotifications "KZR"}}
+					<span class="badge badge-success">{{currencyNotifications "KZR"}}</span>
 				{{/if}}
 			</h4>
             <p class="see-transactions-label">click to see transactions</p>


### PR DESCRIPTION
Solution: Earlier, the transactions with kzr are persisted without currency field.
`id, owner, amount, read..` but no `currency` field for kzr transactions.
(However the transactions with other currencies have currency field exist in the document. )
Later however it was changed, and for new kzr transactions, the currency field exist in the documents. 

This caused kzr notifications not to shown in [/wallet] and mark as read option for kzr not to work for new kzr transactions.