### PR TITLE
Problem: [/currency/x] created times not showing #1511

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -102,7 +102,7 @@ Template.registerHelper('slugify', function(author) {
 })
 
 Template.registerHelper('relativeTime', function(date) {
-  var timePassed = moment(date).fromNow();
+  var timePassed = window.moment(date).fromNow();
   return timePassed;
 });
 


### PR DESCRIPTION
Solution: one line fix as custom file imported and used in the client/main.js as moment, while actual moment.js added as a global variable. Therefore, for other files it is fine as the `moment` refers to global window.moment. But in client/main.js, the `moment` refers to the imported custom file from client/compatibility (which seems not fully implemented yet, dunno though).