### PR TITLE
Problem: Typeahead untested (#1529)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ cache:
 before_script:
   - meteor npm install
   - meteor npm install --unsafe wdio-mocha-framework webdriverio assert
-  - meteor --production &
+  - meteor &
   - sleep 300 # wait for Meteor to start, it takes some time, 5 minutes should be sufficient
  
 script:

--- a/imports/api/coins/methods.js
+++ b/imports/api/coins/methods.js
@@ -284,6 +284,21 @@ export const editCoin = new ValidatedMethod({
     }
 })
 
+if (Meteor.isDevelopment) {
+    Meteor.methods({
+        generateTestCurrencies: () => {
+            for (let i = 0; i < 10; i++) {
+                Currencies.insert({
+                    currencyName: `Test ${i}`,
+                    currencySymbol: `TST${i}`,
+                    createdAt: new Date().getTime(),
+                    owner: 'randId'
+                })
+            }
+        }
+    })
+}
+
 Meteor.methods({
       getCurrentReward: (userId, currencyName) => {
         let bounty = Bounties.findOne({


### PR DESCRIPTION
Solution: Fix two failing test cases in the existing test. The first one has been fixed by commenting out an unnecessary step, and the second one has been fixed by fixing the `listChild` method, as it was returning invalid results in some edge cases. Add a new method for generating test data as CI environment runs with an empty database, and call that method in the test initialization.