### PR TITLE
Problem: Collections in global scope may only be used in development (#1527)

### DIFF
--- a/imports/startup/client/index.js
+++ b/imports/startup/client/index.js
@@ -2,5 +2,5 @@ import ('/imports/ui/components/compatability/index.js')
 import ('bootstrap')
 import '/imports/api/users/client/users.js'
 import '/imports/api/miscellaneous/mime'
-import './testingCollectionGlobals'
 import '../both/routes.js'
+import ('./testingCollectionGlobals')

--- a/imports/startup/client/testingCollectionGlobals.js
+++ b/imports/startup/client/testingCollectionGlobals.js
@@ -1,11 +1,15 @@
-if (Meteor.isDevelopment) {
-import *
-    as
-    collections
-    from
-    '/imports/api/indexDB.js'
+import * as collections from '/imports/api/indexDB.js'
 
-    for (let a in collections) {
-        window[a] = collections[a]
-    }
+for (let a in collections) {
+	// console.log(window[a])
+	if (!window[a]) { // don't override existing globals
+		if (Meteor.isDevelopment) {
+	    	window[a] = collections[a]
+		} else {
+			window[a] = {}
+			window[a]['find'] = window[a]['findOne'] = () => {
+				throw new Meteor.Error('Error.', `You can't reference ${a} globally when in production, please dynamically import it accordingly.`)
+			}
+		}
+	}
 }


### PR DESCRIPTION
Solution: Import all collections dynamically and proxy global collection calls on production to prevent their global usage when in production.