### PR TITLE
Problem: Newly created exchanges are not selected on /addCoin (#1567)

### DIFF
--- a/imports/api/exchanges/methods.js
+++ b/imports/api/exchanges/methods.js
@@ -187,9 +187,9 @@ Meteor.methods({
       throw new Meteor.Error("exchange exists")
     }
     
-    return Exchanges.insert({
+    return Exchanges.findOne(Exchanges.insert({
       name: name,
       curencies: [],
-    })
+    }))
   },
 })

--- a/imports/ui/pages/addCoin/addCoin.js
+++ b/imports/ui/pages/addCoin/addCoin.js
@@ -762,6 +762,12 @@ switch (val) {
         Meteor.call("addExchange", input, (error, result) => {
           if (!error && result) {
             sAlert.success("This exchange has been created")
+
+            if (result._id) {
+              let exchanges = templ.exchanges.get()
+              exchanges.push(result)
+              templ.exchanges.set(exchanges)
+            }
           } else {
             sAlert.error("This exchange already exist.")
           }


### PR DESCRIPTION
Solution: When user creates an exchange on `/addCoin`, automatically add that exchange to the list of selected exchanges for the coin that's being created.