### PR TITLE
Problem: Type error while scrolling down in home (#1550)

### DIFF
--- a/imports/ui/pages/returnedCurrencies/returnedCurrencies.html
+++ b/imports/ui/pages/returnedCurrencies/returnedCurrencies.html
@@ -112,11 +112,10 @@
     {{/if}}
     {{#if reactiveVar 'everythingLoaded'}}
       <div class="end-of-page"> *** End of results ***</div>
-      {{else}}
+    {{/if}}
       <div id="loader">
         <!-- used to determine that page is ending for infinite scroll -->
         <!-- Loading more... -->
       </div>
-    {{/if}}
   </div>
 </template>


### PR DESCRIPTION
Solution: `scrollmagic` requires an element with `loader` id at all times, so don't remove the empty `loader` element even if there are no more results.