### PR TITLE
Problem: Global collections may be only used in development (#1527)

### DIFF
--- a/imports/startup/client/testingCollectionGlobals.js
+++ b/imports/startup/client/testingCollectionGlobals.js
@@ -1,14 +1,13 @@
 import * as collections from '/imports/api/indexDB.js'
 
 for (let a in collections) {
-	// console.log(window[a])
-	if (!window[a]) { // don't override existing globals
+	if (!window[`testing${a}`]) { // don't override existing globals
 		if (Meteor.isDevelopment) {
-	    	window[a] = collections[a]
+	    	window[`testing${a}`] = collections[a]
 		} else {
-			window[a] = {}
-			window[a]['find'] = window[a]['findOne'] = () => {
-				throw new Meteor.Error('Error.', `You can't reference ${a} globally when in production, please dynamically import it accordingly.`)
+			window[`testing${a}`] = {}
+			window[`testing${a}`]['find'] = window[`testing${a}`]['findOne'] = () => {
+				throw new Meteor.Error('Error.', `You can't reference testing${a} globally when in production, please dynamically import it accordingly.`)
 			}
 		}
 	}

--- a/imports/ui/components/typeahead.ui-test.js
+++ b/imports/ui/components/typeahead.ui-test.js
@@ -30,7 +30,7 @@ describe("a:", function () { //typeahead's compareCurrencies implementation
             if (list.children().length) { // this will hold even if the data wasn't found, it'll return the div, so you can check here whether it's a currency or a notFound div and return the appropriate result
                 name = list.children()[0].innerHTML
 
-                return Currencies.findOne({currencyName: name}) || name
+                return testingCurrencies.findOne({currencyName: name}) || name
             } else {
                 return list[0].innerHTML // This is the actual problem that causes tests to fail. innerHTML is currencyName, while we use currencySymbol in the URL. Adding a data attribute with currencySymbol and using that value or something similar should do the trick
             }


### PR DESCRIPTION
Solution: Prefix globally exposed collections with `testing` and throw an error if these are used in production.