### PR TITLE
Problem: 2FA doesn't have backup codes (#1605)

### DIFF
--- a/imports/api/users/server/publications.js
+++ b/imports/api/users/server/publications.js
@@ -114,7 +114,8 @@ import { UserData, ProfileImages, UsersStats } from '/imports/api/indexDB.js'
         inviteCode: 1,
         suspended: 1,
         pass2fa: 1,
-        enabled2fa: 1
+        enabled2fa: 1,
+        backup2fa: 1
 			}
 		})
 	})
@@ -142,9 +143,7 @@ import { UserData, ProfileImages, UsersStats } from '/imports/api/indexDB.js'
 				bio: 1,
 				slug: 1,
 				profilePicture: 1,
-        suspended: 1,
-        pass2fa: 1,
-        enabled2fa: 1
+        suspended: 1
 			} // only show the absolutely required fields
 		})
 	})
@@ -159,9 +158,7 @@ import { UserData, ProfileImages, UsersStats } from '/imports/api/indexDB.js'
         bio: 1,
         slug: 1,
         profilePicture: 1,
-        suspended: 1,
-        pass2fa: 1,
-        enabled2fa: 1
+        suspended: 1
       } // only show the absolutely required fields
     })
   })

--- a/imports/ui/pages/editProfile/editProfile.html
+++ b/imports/ui/pages/editProfile/editProfile.html
@@ -24,7 +24,17 @@
         <div class="form-group">
             <label for="2fa">Two-factor authentication</label>
             {{#if user.enabled2fa}}<div style="width: 100%"><input type="checkbox" checked id="2fa"> Enable</div>{{else}}<div style="width: 100%"><input type="checkbox" id="2fa"> Enable</div>{{/if}}
+            {{#if user.enabled2fa}}<a href="#" id="js-backup2fa">Show backup 2FA tokens</a>{{/if}}
         </div>
+        {{#if show2fa}}
+        <div id="show2fa" class="form-group">
+            {{#each user.backup2fa}}
+            {{this}}<br />
+            {{/each}}
+            <br />
+            Compromised? <a href="#" id="js-regen">Regenerate 2FA backup tokens</a>.
+        </div>
+        {{/if}}
         {{#if enable2fa}}
         <div id="qr2fa" class="form-group">
                 1. Scan the QR code:<br />

--- a/imports/ui/pages/editProfile/editProfile.js
+++ b/imports/ui/pages/editProfile/editProfile.js
@@ -43,6 +43,16 @@ Template.editProfile.events({
             }
         })
     },
+    'click #js-backup2fa': (event, templateInstance) => {
+        event.preventDefault()
+
+        templateInstance.show2fa.set(!templateInstance.show2fa.get())
+    },
+    'click #js-regen': (event, templateInstance) => {
+        event.preventDefault()
+
+        Meteor.call('regenerateBackup2fa', (err, data) => {})
+    },
     'change #2fa': (event, templateInstance) => {
         event.preventDefault()
 
@@ -130,6 +140,7 @@ Template.editProfile.events({
 Template.editProfile.onCreated(function() {
     this.enable2fa = new ReactiveVar(false)
     this.disable2fa = new ReactiveVar(false)
+    this.show2fa = new ReactiveVar(false)
     this.qrcode = new ReactiveVar('')
 })
 
@@ -139,6 +150,7 @@ Template.editProfile.helpers({
             _id: Meteor.userId()
         });
     },
+    show2fa: () => Template.instance().show2fa.get(),
     ProfileImages: () => {
         return ProfileImages.findOne({createdBy:Meteor.userId()});
     },


### PR DESCRIPTION
Solution: Allow users to pass two-factor authentication with predefined backup 2FA tokens. Each of the predefined backup 2FA tokens can be used only once, as it's reset when used. Show 2FA backup tokens on the `editProfile` page so user can save them/write them down. Also, allow users to regenerate all backup 2FA tokens if they believe they may have been compromised.