### PR TITLE
problem: no way to extend bootswatch lux

### DIFF
--- a/imports/ui/layouts/blockrazor.scss
+++ b/imports/ui/layouts/blockrazor.scss
@@ -1,0 +1,1 @@
+$white:    #ff69b4 !default;


### PR DESCRIPTION
solution: add a blockrazor scss file to extend bootstrap and bootswatch when needed #1535