### PR TITLE
Problem: Moderator menu items not working #1719

### DIFF
--- a/imports/ui/shared/sidebar/sidebar.js
+++ b/imports/ui/shared/sidebar/sidebar.js
@@ -48,7 +48,6 @@ Template.sidebar.events({
     },
 
     'click .nav-dropdown': function(event) {
-        event.preventDefault()
         $(event.target).parent().toggleClass("open");
 
     }


### PR DESCRIPTION
Solution: removed inappropriate `preventDefault()` call, which caused all moderator menu items unclickable