### PR TITLE
Problem: Misaligned text in /profile page (#1758)

### DIFF
--- a/imports/ui/pages/userProfile/userProfile.html
+++ b/imports/ui/pages/userProfile/userProfile.html
@@ -22,7 +22,7 @@
                     </li>
                     {{/if}}
                 </ul>
-                <div class="tab-content py-4" style="background-color:#fff;padding:20px">
+                <div class="tab-content py-4" style="background-color:#fff;padding:20px;text-align: left">
                     <div class="tab-pane active" id="profile">
                         <div class="row">
                             <div class="col-md-12">


### PR DESCRIPTION
Solution: Left align all text on all tabs in `/profile` page.