### PR TITLE
Problem: Rough Transitions on Homepage Icons #1814

### DIFF
--- a/imports/ui/layouts/layout.scss
+++ b/imports/ui/layouts/layout.scss
@@ -98,6 +98,8 @@ header.masthead h1 {
 
 .features-icons .features-icons-item .features-icons-icon i {
   font-size: 4.5rem;
+  //Adding transition for smooth animations
+  transition: all 0.2s ease-in-out;
 }
 
 .features-icons .features-icons-item:hover .features-icons-icon i {


### PR DESCRIPTION
 Solution: Add transition property to the icons with ease-in-out.