### PR TITLE
Problem: Kadira requests are being blocked (#1887)

### DIFF
--- a/server/kadira.js
+++ b/server/kadira.js
@@ -1,3 +1,3 @@
 Kadira.connect('Rf5BNXuEusvpJ6xH8', '9856dda8-2974-455b-9185-9ed120517ea8', {
-	endpoint: 'http://58.152.37.119:11011'
+	endpoint: 'https://kadira.emurgolance.org'
 })


### PR DESCRIPTION
Solution: Add SSL support for Kadira engine at domain `kadira.emurgolance.org` and change connection parameters to make sure HTTPS is being used on the client.