### PR TITLE
Problem: Related github repos not considered (#1972)

### DIFF
--- a/i18n/currency.en.i18n.json
+++ b/i18n/currency.en.i18n.json
@@ -73,7 +73,15 @@
 			"exchange_already_appended": "This exchange already appended to ",
 			"exchange_new": "New exchange succesfully added and appended to the ",
 			"exchange_exists": "This exchange already exist.",
-			"typeahead": "@{value} doesn't exist, create and add it to @{parent.currency.currencyName}"
+			"typeahead": "@{value} doesn't exist, create and add it to @{parent.currency.currencyName}",
+			"related_repos": "Related repos",
+			"stargazers": "Stargazers",
+			"watchers": "Watchers",
+			"language": "Language",
+			"fork_count": "Fork count",
+			"last_update": "Last update",
+			"show_more": "Show more repos",
+			"no_related_repos": "No related GitHub repos found."
 		},
 		"discussion": {
 			"discussion": "Discussion",

--- a/imports/api/coins/currencies.js
+++ b/imports/api/coins/currencies.js
@@ -289,6 +289,46 @@ Currencies.schema = new SimpleSchema({
   'exchanges.$._id': {
     type: Id
   },
+  relatedRepos: {
+    type: Array,
+    optional: true
+  },
+  'relatedRepos.$': {
+    type: Object
+  },
+  'relatedRepos.$.id': {
+    type: String
+  },
+  'relatedRepos.$.name': {
+    type: String
+  },
+  'relatedRepos.$.html_url': {
+    type: String
+  },
+  'relatedRepos.$.fork': {
+    type: String
+  },
+  'relatedRepos.$.created_at': {
+    type: String
+  },
+  'relatedRepos.$.updated_at': {
+    type: String
+  },
+  'relatedRepos.$.stargazers_count': {
+    type: String
+  },
+  'relatedRepos.$.watchers_count': {
+    type: String
+  },
+  'relatedRepos.$.language': {
+    type: String
+  },
+  'relatedRepos.$.forks_count': {
+    type: String
+  },
+  'relatedRepos.$.score': {
+    type: Number
+  },
   launchTags: {
     type: Array,
     minCount: 1,

--- a/imports/api/coins/server/startup.js
+++ b/imports/api/coins/server/startup.js
@@ -1,0 +1,9 @@
+import { Mongo } from 'meteor/mongo'
+
+Meteor.startup(() => {
+    SyncedCron.add({
+        name: 'Fetch related github repos',
+        schedule: (parser) => parser.cron('0 0 * * 0'), // every 7 days will be sufficient
+        job: () => Meteor.call('fetchRelatedGithubRepos', (err, data) => {})
+    })
+})

--- a/imports/startup/server/index.js
+++ b/imports/startup/server/index.js
@@ -33,6 +33,7 @@ import '/imports/api/auctions/server/startup'
 import '/imports/api/rewards/server/startup'
 import '/imports/api/problems/server/startup'
 import '/imports/api/encryption/server/startup'
+import '/imports/api/coins/server/startup'
 
 // collection configs
 import '/imports/api/users/users.js'

--- a/imports/ui/pages/currencyDetail/currencyInfo.html
+++ b/imports/ui/pages/currencyDetail/currencyInfo.html
@@ -38,6 +38,9 @@
                   <li class="nav-item">
                     <a class="nav-link" data-toggle="tab" href="#exchangestab">{{_ "currency.info.exchanges"}}</a>
                   </li>
+                  <li class="nav-item">
+                    <a class="nav-link" data-toggle="tab" href="#repostab">{{_ "currency.info.related_repos"}}</a>
+                  </li>
                 </ul>
                 <div id="currencyTabContent" class="tab-content">
                   <div class="tab-pane fade show active" id="compendiumtab">
@@ -193,6 +196,30 @@
             {{_ "currency.info.no_exchanges"}}
           {{/if}}
 
+                    </div>
+                  </div>
+                  <div class="tab-pane fade show active" id="repostab">
+                    <br/>
+                    <div class="row">
+                      {{#if relatedRepos.length}}
+                        {{#each relatedRepos}}
+                        <div class="col-md-4">
+                          <div class="card card-header">
+                            <div class="title"><a target="_blank" href="{{html_url}}">{{name}}</a>{{#if fork}}<i class="fa fa-code-fork" aria-hidden="true"></i>{{/if}}</div>
+                            <div class="value">
+                              {{_ "currency.info.stargazers"}}: <b>{{isNullReadOnly stargazers_count}}</b><br />
+                              {{_ "currency.info.watchers"}}: <b>{{isNullReadOnly watchers_count}}</b><br />
+                              {{_ "currency.info.language"}}: <b>{{isNullReadOnly language}}</b><br />
+                              {{_ "currency.info.fork_count"}}: <b>{{isNullReadOnly forks_count}}</b><br />
+                              {{_ "currency.info.last_update"}}: <b>{{formatDate updated_at}}</b>
+                            </div>
+                          </div>
+                        </div>
+                        {{/each}}
+                        {{#if reposHasMore}}<a class="btn btn-secondary pull-right" id="js-show-more">{{_ "currency.info.show_more"}}</a>{{/if}}
+                      {{else}}
+                        <h4>{{_ "currency.info.no_related_repos"}}</h4>
+                      {{/if}}
                     </div>
                   </div>
                 </div>

--- a/imports/ui/pages/currencyDetail/currencyInfo.js
+++ b/imports/ui/pages/currencyDetail/currencyInfo.js
@@ -35,6 +35,8 @@ Template.currencyInfo.onCreated(function () {
       }))
     }
   })
+
+    this.reposShow = new ReactiveVar(9)
 })
 
 Template.currencyInfo.onRendered(function () {
@@ -357,10 +359,24 @@ Template.currencyInfo.events({
         sAlert.error(TAPi18n.__('currency.info.exchange_problem') + templ.currency.currencyName)
       }
     })
-  }
+  },
+    'click #js-show-more': (event, templateInstance) => {
+        event.preventDefault()
+
+        templateInstance.reposShow.set(templateInstance.reposShow.get() + 9)
+    }
 });
 
 Template.currencyInfo.helpers({
+    relatedRepos: () => {
+        let repos = Template.instance().data.relatedRepos || []
+
+        return repos.sort((i1, i2) => Number(i2.score) - Number(i1.score)).slice(0, Template.instance().reposShow.get())
+    },
+    formatDate: (val) => {
+        return moment(new Date(val)).format(_globalDateFormat)
+    },
+    reposHasMore: () => Template.instance().reposShow.get() <= Template.instance().data.relatedRepos.length,
   newAlgo: () => Template.instance().newAlgo.get() ? 'block' : 'none',
   showText: () => Template.instance().showText.get() ? 'block' : 'none',
   previousNames: () => {


### PR DESCRIPTION
Solution: Use the GitHub search API to populate a collection with relevant related repos for each currency. Take care of GitHub's rate limiting with appropriate pauses. Show fetched data in a new tab on the currency detail page.