### PR TITLE
Problem: No IP whitelist for banning system (#1978)

### DIFF
--- a/imports/api/activityLog/methods.js
+++ b/imports/api/activityLog/methods.js
@@ -52,6 +52,28 @@ Meteor.methods({
 })
 
 Meteor.methods({
+  activityIPFixture: () => {
+    let ip = ActivityIPs.findOne({
+      ip: '127.0.0.1'
+    })
+
+    if (!ip) {
+      ActivityIPs.insert({
+        ip: '127.0.0.1',
+        ignored: true,
+        whitelist: true
+      })
+    } else if (ip && (!ip.whitelist || !ip.ignored)) {
+      ActivityIPs.update({
+        _id: ip._id,
+      }, {
+        $set: {
+          ignored: true,
+          whitelist: true
+        }
+      })
+    }
+  },
   activityIPVote: function(ip, type) {
     if (!Meteor.userId()) {
       throw new Meteor.Error('Error.', 'messages.login')

--- a/imports/startup/server/fixtures.js
+++ b/imports/startup/server/fixtures.js
@@ -139,6 +139,4 @@ if (FormData.find().count() === 0) {
       },].forEach(doc => {FormData.insert(doc)})
 };
 
-
-
-
+Meteor.call('activityIPFixture', (err, data) => {})

--- a/imports/ui/pages/moderator/flaggedUsers/flaggedUsers.js
+++ b/imports/ui/pages/moderator/flaggedUsers/flaggedUsers.js
@@ -58,9 +58,13 @@ Template.flaggedUsers.helpers({
 		let ips = _.uniq(_.flatten(users.map(i => ((i.info.sessionData || []).map(j => j.loggedIP))))) // return all flagged ip addresses
 		let ignored = ActivityIPs.find({
 			ignored: true,
-			time: {
-				$gt: new Date() - 1000*60*60*24*30
-			}
+			$or: [{
+				time: {
+					$gt: new Date() - 1000*60*60*24*30
+				}
+			}, {
+				whitelist: true
+			}]
 		}).fetch().map(i => i.ip)
 
 		ips = ips.filter(i => !~ignored.indexOf(i)) // filter out ignored ips


### PR DESCRIPTION
Solution: Modify the current ignore IP mechanism and add a `whitelist` flag to ignored IPs list to denote a whitelisted IP which has no expiry time. Add a fixture to add 127.0.0.1 to the list if it's not already there. Check this list for addresses before using them.