### PR TITLE
Problem: There's no summary of github projects for currencies (#1988)

### DIFF
--- a/i18n/currency.en.i18n.json
+++ b/i18n/currency.en.i18n.json
@@ -81,7 +81,12 @@
 			"fork_count": "Fork count",
 			"last_update": "Last update",
 			"show_more": "Show more repos",
-			"no_related_repos": "No related GitHub repos found."
+			"no_related_repos": "No related GitHub repos found.",
+			"related": "Related projects on Github",
+			"watchers_all": "Watchers on all projects",
+			"likes": "Likes on all projects",
+			"watchers_avg": "Watchers per project",
+			"top_langs": "Top 5 languages"
 		},
 		"discussion": {
 			"discussion": "Discussion",

--- a/imports/api/coins/currencies.js
+++ b/imports/api/coins/currencies.js
@@ -329,6 +329,28 @@ Currencies.schema = new SimpleSchema({
   'relatedRepos.$.score': {
     type: Number
   },
+  gitStats: {
+    type: Object,
+    optional: true
+  },
+  'gitStats.related': {
+    type: Number
+  },
+  'gitStats.watchers': {
+    type: Number
+  },
+  'gitStats.likes': {
+    type: Number
+  },
+  'gitStats.avgWatchers': {
+    type: Number
+  },
+  'gitStats.topLanguages': {
+    type: Array
+  },
+  'gitStats.topLanguages.$': {
+    type: String
+  },
   launchTags: {
     type: Array,
     minCount: 1,

--- a/imports/api/coins/methods.js
+++ b/imports/api/coins/methods.js
@@ -350,11 +350,22 @@ Meteor.methods({
                         score: i.score
                     }))
 
+                    let languages = {}
+
+                    items.forEach(j => languages[j.language] = (languages[j.language] || 0) + 1)
+
                     Currencies.update({
                         _id: el._id
                     }, {
                         $set: {
-                            relatedRepos: items
+                            relatedRepos: items,
+                            gitStats: {
+                                related: data.data.total_count,
+                                watchers: items.reduce((i1, i2) => i1 + Number(i2.watchers_count), 0),
+                                likes: items.reduce((i1, i2) => i1 + Number(i2.stargazers_count), 0),
+                                avgWatchers: Math.round(items.reduce((i1, i2) => i1 + Number(i2.watchers_count), 0) / (items.length || 1)),
+                                topLanguages: Object.keys(languages).sort((i1, i2) => languages[i2] - languages[i1]).slice(0, 5)
+                            }
                         }
                     })
                 }

--- a/imports/api/coins/server/startup.js
+++ b/imports/api/coins/server/startup.js
@@ -3,7 +3,7 @@ import { Mongo } from 'meteor/mongo'
 Meteor.startup(() => {
     SyncedCron.add({
         name: 'Fetch related github repos',
-        schedule: (parser) => parser.cron('0 0 * * 0'), // every 7 days will be sufficient
+        schedule: (parser) => parser.cron('0 1 * * *'), // every day will be sufficient
         job: () => Meteor.call('fetchRelatedGithubRepos', (err, data) => {})
     })
 })

--- a/imports/ui/pages/currencyDetail/currencyInfo.html
+++ b/imports/ui/pages/currencyDetail/currencyInfo.html
@@ -198,9 +198,23 @@
 
                     </div>
                   </div>
-                  <div class="tab-pane fade show active" id="repostab">
+                  <div class="tab-pane fade" id="repostab">
                     <br/>
                     <div class="row">
+                      {{#if gitStats}}
+                        <div class="col-md-12">
+                          <div class="card card-header">
+                            <div class="title">Git stats</div>
+                            <div class="value">
+                              {{_ "currency.info.related"}}: <b>{{isNullReadOnly gitStats.related}}</b><br />
+                              {{_ "currency.info.watchers_all"}}: <b>{{isNullReadOnly gitStats.watchers}}</b><br />
+                              {{_ "currency.info.likes"}}: <b>{{isNullReadOnly gitStats.likes}}</b><br />
+                              {{_ "currency.info.watchers_avg"}}: <b>{{isNullReadOnly gitStats.avgWatchers}}</b><br />
+                              {{_ "currency.info.top_langs"}}: <b>{{topLangs}}</b>
+                            </div>
+                          </div>
+                        </div>
+                      {{/if}}
                       {{#if relatedRepos.length}}
                         {{#each relatedRepos}}
                         <div class="col-md-4">

--- a/imports/ui/pages/currencyDetail/currencyInfo.js
+++ b/imports/ui/pages/currencyDetail/currencyInfo.js
@@ -368,6 +368,9 @@ Template.currencyInfo.events({
 });
 
 Template.currencyInfo.helpers({
+    topLangs: function() {
+        return this.gitStats.topLanguages.toString().replace(/,/g, ', ')
+    },
     relatedRepos: () => {
         let repos = Template.instance().data.relatedRepos || []
 


### PR DESCRIPTION
Solution: Add a summary on the currency details page that includes: related projects on Github, watchers on all projects, likes on all projects, watchers per project and top 5 languages. Stats are updated daily with a cron job.