### PR TITLE
Problem: Can't sort suspicious IP's by IP login time (#1983)

### DIFF
--- a/imports/ui/pages/moderator/flaggedUsers/flaggedUsers.js
+++ b/imports/ui/pages/moderator/flaggedUsers/flaggedUsers.js
@@ -91,10 +91,10 @@ Template.flaggedUsers.helpers({
 				return {
 					ip: i,
 					lastAccess: moment(lastAccess).fromNow(),
-					lastAccessIP: moment(ip.lastAccess).fromNow(),
+					lastAccessIP: ip.lastAccess ? moment(ip.lastAccess).fromNow() : '-',
 					users: us.length,
 					lastAccessSort: lastAccess,
-					lastAccessIPSort: ip.lastAccess
+					lastAccessIPSort: ip.lastAccess || 0
 				}
 			} else {
 				return false


### PR DESCRIPTION
Solution: Make sure that sorting works even when some data is not available.